### PR TITLE
feat: add delegate addon — task delegation to cheaper/faster models

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ After installing, restart piclaw to load the extension.
 | [code-validator](addons/code-validator) | extension | 0.1.0 | Diagnostics tool for code validation | — |
 | [dev-tools](addons/dev-tools) | extension | 0.1.0 | Developer tools for workspace diagnostics | — |
 | [kanban-board-widget](addons/kanban-board-widget) | extension | 0.1.0 | Interactive kanban board widget | — |
+| [delegate](addons/delegate) | extension | 0.1.0 | Delegate tasks to cheaper/faster models with auto model selection | delegate |
 
 ## Add-on Manifest Format
 

--- a/addons/delegate/README.md
+++ b/addons/delegate/README.md
@@ -1,0 +1,80 @@
+# Delegate
+
+Send tasks to a cheaper/faster model in a fresh context with auto model selection, tool access, and MCP support.
+
+## Features
+
+- **Auto model selection** — picks the best model for the task category, never exceeding the current model's tier
+- **6 task categories** — quick, summarize, code, analyze, reason, judge
+- **Tool access** — delegate has read, grep, find, ls, bash, MCP tools by default
+- **MCP support** — any servers in `.pi/mcp.json` are available
+- **Multimodal** — images/PDFs passed as native attachments with automatic tier bumping
+- **Judge mode** — cross-family second opinion for reviewing agent responses
+- **Skills** — all `.pi/skills/` auto-discovered (web-search, etc.)
+- **Fresh context** — no conversation history, saves tokens
+
+## Install
+
+```bash
+cp extensions/delegate.ts /workspace/.pi/extensions/
+cp -r skills/delegate /workspace/.pi/skills/
+```
+
+Then restart PiClaw. The extension **auto-activates** itself — no manual `activate_tools` needed.
+
+> **Note:** PiClaw automatically creates a `node_modules` symlink in `.pi/extensions/` on startup to resolve framework packages (`@sinclair/typebox`, etc.). No manual symlink is needed.
+
+### Optional: config-based activation
+
+You can also add delegate to the default active tools in `.piclaw/config.json`:
+
+```json
+{
+  "tools": {
+    "additionalDefaultTools": ["delegate"]
+  }
+}
+```
+
+## Stress test results
+
+Tested on 12-core / 7.5GB container (github-copilot provider):
+
+| Concurrency | Success rate | Avg latency | Max latency | Memory delta |
+|---|---|---|---|---|
+| 1 | 100% | 3.6s | 3.6s | — |
+| 5 | 100% | 2.4s | 3.1s | — |
+| 10 | 100% | 2.5s | 3.0s | +7 MB |
+| 20 | 100% | 3.3s | 5.6s | +3 MB |
+| 30 | 100% | 3.8s | 4.6s | +14 MB |
+
+Safe for up to 20 concurrent calls. Bottleneck is API rate limits, not local resources.
+
+### Running the stress test
+
+```bash
+# Phase 1: basic concurrency (1, 2, 3, 5, 8, 10)
+bun tests/delegate-stress-test.ts
+
+# Phase 2: higher load + memory monitoring (10, 15, 20, 25, 30)
+bun tests/delegate-stress-test-2.ts
+```
+
+This is redundant if using the extension (it self-activates), but useful if you want explicit config control.
+
+## Quick reference
+
+| Category | Model picked | Use for |
+|---|---|---|
+| `quick` | gpt-5.4-mini (tier 2) | Formatting, factual Q&A, translation |
+| `summarize` | gpt-5.4-mini (tier 2) | File/note/code summaries |
+| `code` | claude-sonnet-4.6 (tier 3) | Code gen, refactoring |
+| `analyze` | claude-sonnet-4.6 (tier 3) | Code review, debugging |
+| `reason` | claude-sonnet-4.6 (tier 3) | Complex logic — if you need frontier, don't delegate |
+| `judge` | Different family than current (tier 3) | Second opinion, verify, double check |
+
+| Tool profile | Tools included |
+|---|---|
+| `read_only` | read, grep, find, ls, mcp |
+| `standard` (default) | read, grep, find, ls, bash, mcp |
+| `full` | read, grep, find, ls, bash, edit, write, mcp |

--- a/addons/delegate/REFERENCE.md
+++ b/addons/delegate/REFERENCE.md
@@ -1,0 +1,557 @@
+# Delegate Extension — Complete Reference
+
+**Date:** 2026-04-23  
+**Extension:** `/workspace/.pi/extensions/delegate.ts`  
+**Skill:** `/workspace/.pi/skills/delegate/SKILL.md`
+
+---
+
+## 1. Why
+
+LLM conversations accumulate context. Every message, tool result, and system prompt stays in the context window until compacted. In a typical PiClaw session:
+
+- **System prompt + memory + skills:** ~6,000+ tokens (always loaded)
+- **Conversation history:** grows to 100K–200K+ tokens over a session
+- **Every agent call processes the FULL context** — even for "what is 2+2?"
+
+This means a simple file summary costs the same input tokens as a complex architecture discussion. The delegate tool solves this by running tasks in a **fresh context** with a **cheaper model**, then returning the result inline.
+
+**Real-world savings measured:** 5 delegate calls used ~12K total input tokens vs ~893K if done by the main agent — a **99% reduction**.
+
+---
+
+## 2. What
+
+A PiClaw extension that registers a `delegate` tool. When called, it:
+
+1. Selects an appropriate model based on the task category
+2. Spawns `pi --print --model <model> --tools <list>` as a subprocess
+3. The subprocess runs with its own fresh context (no conversation history)
+4. Has access to tools (read, grep, bash, MCP) and skills (web-search, etc.)
+5. Returns the response inline to the current conversation
+
+The delegate is a **full agent** — not just an API call. It can read files, run commands, search the web, and use MCP tools. It just doesn't carry the main agent's conversation baggage.
+
+---
+
+## 3. How it works
+
+### Execution flow
+
+```
+Main Agent (full context)              Delegate (fresh context)
+        │                                      │
+        │  delegate({ prompt, category })      │
+        │                                      │
+        │  1. Select model (tier system)       │
+        │  2. Detect visual input → tier bump  │
+        │  3. spawn("pi", args) directly       │
+        │     --print --no-extensions          │
+        │     --model <selected>               │
+        │     --tools <profile>                │
+        │     -e mcp-adapter                   │
+        │     -e safe-workspace-extensions     │
+        │     --append-system-prompt <hints>   │
+        │     @image.jpg (if binary files)     │
+        │                                      │
+        │  4. Write prompt to child.stdin      │
+        │     child.stdin.end()                │
+        │                                      │
+        │  5. pi runs with tools ──────────►   │
+        │                                      │  Reads files, runs bash
+        │                                      │  Uses MCP, web search
+        │  ◄─── stdout captured ───────────    │
+        │                                      │
+        │  6. Return result inline             │
+        │  7. Process cleanup (automatic)      │
+```
+
+### What the delegate gets
+
+| Resource | How |
+|---|---|
+| **Tools** | `--tools read,grep,find,ls,bash,mcp` (configurable) |
+| **MCP servers** | MCP adapter loaded via `-e`, reads `.pi/mcp.json` |
+| **Skills** | Auto-discovered from `.pi/skills/` (web-search, etc.) |
+| **Workspace extensions** | Safe extensions from `.pi/extensions/` (excludes delegate itself and UI-only) |
+| **Capability hints** | `--append-system-prompt` with web-search and MCP usage instructions |
+
+### What the delegate does NOT get
+
+| Resource | Why |
+|---|---|
+| **Conversation history** | That's the whole point — fresh context |
+| **Memory files** | Not injected (saves tokens) |
+| **AGENTS.md** | Not the full version (pi --print uses minimal system prompt) |
+| **The delegate tool itself** | Excluded to prevent recursion |
+| **UI-only extensions** | Excluded (kanban-board-widget, etc.) |
+
+---
+
+## 4. Model tier system
+
+### 5-tier hierarchy
+
+Models are organized into tiers based on capability and cost. The delegate never picks a model above the current agent's tier.
+
+| Tier | Strength | Speed | Models (preference order) |
+|---|---|---|---|
+| **1** | Light | Fast | gpt-4o, gpt-4.1, claude-haiku-4.5, grok-code-fast-1 |
+| **2** | Medium | Fast | **gpt-5.4-mini**, gpt-5.1-codex-mini, gpt-5-mini, gemini-3-flash-preview |
+| **3** | Strong | Medium | **claude-sonnet-4.6**, claude-sonnet-4.5, claude-sonnet-4, gpt-5.4, gpt-5.2, gpt-5.1, gpt-5, gemini-3.1-pro, gemini-3-pro, gemini-2.5-pro |
+| **4** | Strong | Medium | gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex, gpt-5.1-codex-max |
+| **5** | Frontier | Slow | claude-opus-4.7, claude-opus-4.6, claude-opus-4.5 |
+
+**Preference order matters:** Within each tier, the first model in the list is preferred. This means gpt-5.4-mini is chosen over gpt-5-mini (both tier 2), and claude-sonnet-4.6 over claude-sonnet-4 (both tier 3).
+
+### Category → tier mapping
+
+Each task category has a **target tier**. The delegate picks the best model at that tier:
+
+| Category | Target tier | Default pick | Rationale |
+|---|---|---|---|
+| `quick` | 2 | gpt-5.4-mini | Cheapest capable model — formatting, Q&A, extraction don't need reasoning |
+| `summarize` | 2 | gpt-5.4-mini | Fast comprehension is enough — reading + condensing |
+| `code` | 3 | claude-sonnet-4.6 | Code gen needs stronger reasoning but not frontier |
+| `analyze` | 3 | claude-sonnet-4.6 | Code review and debugging need reasoning depth |
+| `reason` | 3 | claude-sonnet-4.6 | Strong reasoning — if you need frontier, don't delegate |
+| `judge` | 3 | *Different family* | Must come from a different model family (see below) |
+
+### Tier cap
+
+The delegate never picks a model above the current agent's tier. If you're running on:
+- **claude-opus-4.6** (tier 5) → full range available (tiers 1-5)
+- **claude-sonnet-4.6** (tier 3) → tiers 1-3 only
+- **gpt-5.4-mini** (tier 2) → tiers 1-2 only
+
+### Fallback behavior
+
+If the target tier isn't available (e.g., target is 3 but max is 2), the delegate falls back to the nearest lower tier.
+
+---
+
+## 5. Task categories
+
+### `quick` — Fast and cheap
+
+**Target:** Tier 2 (gpt-5.4-mini)
+
+For tasks that need speed, not depth:
+- Factual Q&A ("What is 2+2?")
+- Formatting and translation
+- Data extraction from structured text
+- Simple counting or listing
+
+### `summarize` — Comprehension without reasoning
+
+**Target:** Tier 2 (gpt-5.4-mini)
+
+For condensing information:
+- File summaries
+- Note digests
+- Code overviews
+- Meeting notes condensation
+
+### `code` — Code generation and refactoring
+
+**Target:** Tier 3 (claude-sonnet-4.6)
+
+For tasks that need code understanding:
+- Code generation
+- Refactoring
+- Mechanical edits across files
+- Writing tests
+
+### `analyze` — Review and debugging
+
+**Target:** Tier 3 (claude-sonnet-4.6)
+
+For tasks that need reasoning about code or systems:
+- Code review
+- Architecture analysis
+- Bug analysis
+- Security review
+
+### `reason` — Complex logic
+
+**Target:** Tier 3 (claude-sonnet-4.6)
+
+For multi-step reasoning tasks:
+- Planning and design
+- Complex problem solving
+- Multi-factor decision analysis
+
+**Important:** If a task genuinely needs frontier-level reasoning (opus), don't delegate — do it directly.
+
+### `judge` — Cross-family second opinion
+
+**Target:** Tier 3, **different model family**
+
+For reviewing and critiquing the main agent's output:
+- Fact-checking responses
+- Catching inaccuracies
+- Identifying missing information
+- Challenging assumptions
+
+**Cross-family selection:** When the main agent is Claude, the judge picks GPT (and vice versa). This ensures genuinely different training biases — not the same model agreeing with itself.
+
+| Current agent family | Judge picks |
+|---|---|
+| Claude (opus/sonnet) | gpt-5.4 (GPT family, tier 3) |
+| GPT (any) | claude-sonnet-4.6 (Claude family, tier 3) |
+| Gemini | claude-sonnet-4.6 (Claude family, tier 3) |
+
+**Triggered by:** User saying "double check", "verify", "review your answer", "second opinion", or similar.
+
+---
+
+## 6. Multimodal support
+
+### How files are handled
+
+The delegate separates files into two types:
+
+| File type | Examples | How passed | Processed by |
+|---|---|---|---|
+| **Text** | `.ts`, `.md`, `.json`, `.txt`, `.py` | Read as UTF-8, inlined in prompt | All models |
+| **Binary/image** | `.png`, `.jpg`, `.pdf`, `.svg`, `.gif` | Passed as `@/path/to/file` arg | Vision-capable models |
+
+### Automatic tier bumping
+
+When binary/image files are detected, the delegate **automatically bumps** the model tier if the auto-selected model is below tier 3:
+
+| Category | Without images | With images |
+|---|---|---|
+| `quick` | gpt-5.4-mini (tier 2) | **claude-sonnet-4.6 (tier 3)** ↑ bumped |
+| `summarize` | gpt-5.4-mini (tier 2) | **claude-sonnet-4.6 (tier 3)** ↑ bumped |
+| `code` | claude-sonnet-4.6 (tier 3) | claude-sonnet-4.6 — already tier 3 |
+| `analyze` | claude-sonnet-4.6 (tier 3) | claude-sonnet-4.6 — already tier 3 |
+
+**Why:** While all models technically support images, tier 3 models have significantly better visual understanding for dense content like charts, diagrams, screenshots, and PDFs.
+
+**No bump when:** You explicitly set `model` — manual override disables auto-bumping.
+
+### Supported binary extensions
+
+Images: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`, `.tiff`, `.tif`, `.svg`, `.ico`  
+Documents: `.pdf`  
+Archives: `.zip`, `.tar`, `.gz`  
+Media: `.mp3`, `.wav`, `.mp4`, `.webm`
+
+---
+
+## 7. Tool profiles
+
+Three built-in profiles control what tools the delegate can use:
+
+| Profile | Tools | When to use |
+|---|---|---|
+| `read_only` | read, grep, find, ls, mcp | Safe exploration — can't modify anything |
+| `standard` (default) | read, grep, find, ls, bash, mcp | Most tasks — can run commands |
+| `full` | read, grep, find, ls, bash, edit, write, mcp | Code generation that writes files |
+
+All profiles include **MCP** access by default.
+
+You can also pass a custom comma-separated tool list: `tools: "read,grep,bash"`.
+
+---
+
+## 8. Extension and skill discovery
+
+### Extensions loaded in delegate
+
+The delegate uses `--no-extensions` to avoid loading itself recursively, then explicitly loads:
+
+1. **MCP adapter** — auto-discovered from bun global install
+2. **Safe workspace extensions** — all `.ts` files in `.pi/extensions/` except:
+   - `delegate.ts` (prevent recursion)
+   - `kanban-board-widget.ts` (UI-only)
+
+New extensions you add to `.pi/extensions/` are automatically available.
+
+### Skills
+
+All skills in `.pi/skills/` are auto-discovered by the delegate's `pi --print` subprocess. This includes:
+- Web search (SearXNG)
+- Web search summary
+- Diagnostics
+- Dev tools
+- Any skills you add in the future
+
+### Capability hints
+
+Cheap models sometimes don't discover skills on their own. The delegate injects capability hints via `--append-system-prompt`:
+
+```
+Web search: run 'bun /workspace/.pi/skills/web-search/web-search.ts --query "QUERY" --fetch true --fetch-limit 3'
+Web search summary: run 'bun /workspace/.pi/skills/web-search-summary/web-search-summary.ts --query "QUERY"'
+MCP: use the mcp tool with action 'call_tool' to call MCP server tools.
+```
+
+---
+
+## 9. Token economics
+
+### Why delegation saves tokens
+
+Every LLM call processes the **full context window**:
+
+```
+[system prompt] + [memory] + [conversation history] + [new message]
+         ↓                          ↓
+    ~6K tokens              100K-200K tokens
+```
+
+A delegate call processes only:
+
+```
+[minimal system prompt] + [task prompt] + [file contents if any]
+         ↓                     ↓                  ↓
+    ~1K tokens           ~0.5K tokens        varies
+```
+
+### Real-world measurement
+
+From a session with 178K context tokens, 5 delegate calls:
+
+| | Main agent | Delegate | Savings |
+|---|---|---|---|
+| Input tokens (5 calls) | ~893K | ~12K | **881K (99%)** |
+| Context per call | 178K | 0.5-4.5K | Fresh each time |
+| Models used | opus (frontier) | mini/sonnet | Cheaper tiers |
+
+### When to delegate vs do directly
+
+| Delegate | Do directly |
+|---|---|
+| Self-contained task (no history needed) | Needs conversation context |
+| Simple/mechanical work | Complex multi-step reasoning |
+| File summaries, lookups, searches | Architecture decisions |
+| Can describe fully in one prompt | Requires back-and-forth |
+| Any task category except frontier-level | Needs the most capable model |
+
+---
+
+## 10. Usage examples
+
+### Natural conversation
+
+You don't need to remember the syntax. Just ask naturally:
+
+- "Summarize my sessions note" → agent delegates with `summarize`
+- "How many workitems do I have?" → agent delegates with `quick`
+- "Search the web for SearXNG releases" → agent delegates with `quick` + web search
+- "Double check that answer" → agent delegates with `judge` (cross-family)
+- "Describe this screenshot" → agent delegates with tier bump for image
+
+### Explicit tool calls
+
+```typescript
+// Quick factual question
+delegate({ prompt: "What is 2+2?", task_category: "quick" })
+
+// File summary
+delegate({
+  prompt: "Summarize in 3 bullets",
+  files: ["notes/piclaw-tasks.md"],
+  task_category: "summarize"
+})
+
+// Code analysis with specific model
+delegate({
+  prompt: "List all exported functions",
+  files: [".pi/extensions/delegate.ts"],
+  task_category: "code"
+})
+
+// Web search
+delegate({
+  prompt: "Search the web for 'SearXNG latest release' and show top 3",
+  task_category: "quick"
+})
+
+// MCP query
+delegate({
+  prompt: "Search Microsoft Learn for 'Azure Bicep modules'",
+  task_category: "quick"
+})
+
+// Image analysis (auto tier bump)
+delegate({
+  prompt: "Describe this image",
+  files: ["screenshot.png"],
+  task_category: "quick"  // bumped to tier 3 automatically
+})
+
+// Judge / second opinion
+delegate({
+  prompt: "Review this for accuracy:\n\n<response>\n...\n</response>",
+  task_category: "judge"
+})
+
+// Full tool access for code generation
+delegate({
+  prompt: "Create a hello world Express server",
+  task_category: "code",
+  tools: "full"
+})
+```
+
+---
+
+## 11. Architecture decisions
+
+| Decision | Rationale |
+|---|---|
+| `pi --print` subprocess | Uses existing auth, model registry, and tool infrastructure — no need to reimplement |
+| Direct `spawn("pi", args)` | No shell wrapper — SIGTERM kills the actual pi process, not a bash parent. Prevents orphaned subprocesses |
+| Stdin piping (`child.stdin.write + end`) | Prompt sent directly to pi's stdin. No temp files, no shell escaping issues |
+| `settled` guard + shared `cleanup()` | Single-settlement promise: timeout, abort, close, and error all check `settled` flag. `cleanup()` clears timer, kill-timer, and abort listener on every path |
+| Self-activation in `before_agent_start` | Extension calls `pi.setActiveTools()` to add itself — no manual `activate_tools` or config needed |
+| `--no-extensions` + explicit `-e` | Prevents recursive delegate loading while keeping MCP and safe extensions |
+| Temp file for prompt | Avoids shell escaping issues with complex prompts containing quotes, newlines, code |
+| `@file` for binary attachments | Native pi syntax for image/PDF passthrough — no base64 encoding needed |
+| Category → tier (not model) | Decouples task intent from specific models — works across providers |
+| Cross-family judge | Different training biases catch different errors — same-model review is confirmation bias |
+| Tier bump for images | Cheap models technically support vision but quality varies significantly |
+| Capability hints in system prompt | Cheap models don't proactively discover skills — explicit hints ensure web search and MCP work |
+| Models ordered by preference in tier | `find()` returns first match — ordering controls which model is preferred within a tier |
+
+---
+
+## 12. Limitations
+
+- **No streaming** — response is returned all at once after subprocess completes
+- **No conversation continuity** — each delegate call is stateless
+- **Timeout** — default 120s, max 300s — long tasks may fail
+- **Output truncation** — responses capped at 50K chars, buffered output capped at 100K
+- **No hard tool enforcement** — tool profiles are allowlists, not blocklists
+- **Provider-specific tiers** — model tier table is for github-copilot provider; needs updating for other providers
+- **File size limit** — text files >100KB are rejected for inlining (delegate can read them via tools instead)
+- **Workspace sandboxed** — files parameter only accepts paths under `/workspace/`
+
+---
+
+## 13. Stress test results
+
+Tested on 12-core ARM / 7.5GB container with `github-copilot/gpt-5.4-mini`.
+
+### Phase 1: basic concurrency
+
+| Concurrency | Success | Avg (ms) | Min (ms) | Max (ms) | Wall (ms) |
+|---|---|---|---|---|---|
+| 1 | 1/1 | 3,646 | 3,646 | 3,646 | 3,646 |
+| 2 | 2/2 | 2,741 | 2,678 | 2,804 | 2,804 |
+| 3 | 3/3 | 2,409 | 2,206 | 2,805 | 2,812 |
+| 5 | 5/5 | 2,438 | 2,036 | 3,115 | 3,120 |
+| 8 | 8/8 | 2,711 | 2,277 | 3,834 | 3,837 |
+| 10 | 10/10 | 3,294 | 2,396 | 4,609 | 4,611 |
+
+### Phase 2: higher load + memory monitoring
+
+| Concurrency | Success | Avg (ms) | Max (ms) | Mem delta |
+|---|---|---|---|---|
+| 10 | 10/10 | 2,472 | 3,038 | +7 MB |
+| 15 | 15/15 | 2,910 | 4,553 | +0 MB |
+| 20 | 20/20 | 3,331 | 5,616 | +3 MB |
+| 25 | 25/25 | 4,033 | 17,567 | +5 MB |
+| 30 | 30/30 | 3,847 | 4,647 | +14 MB |
+
+### Key findings
+
+- **Zero failures** at any concurrency level (0–30)
+- **Memory is stable** — 7–14 MB delta per batch, fully reclaimed
+- **Latency degrades gracefully** — avg 2.5s → 4s at 30 concurrent
+- **Bottleneck is the API**, not local resources
+- **One outlier** at 25 concurrent (17.6s max) — likely API rate limiting
+
+### Safe concurrency recommendations
+
+| Usage | Max concurrent | Notes |
+|---|---|---|
+| Normal use | 1–3 | What the agent typically does |
+| Safe burst | 10 | Negligible impact |
+| Aggressive | 20 | Slight latency increase |
+| Limit | 30+ | Works but API may throttle |
+
+### Running the tests
+
+```bash
+# From the delegate package directory:
+
+# Phase 1: basic concurrency (1, 2, 3, 5, 8, 10)
+bun tests/delegate-stress-test.ts
+
+# Phase 2: higher load + memory monitoring (10, 15, 20, 25, 30)
+bun tests/delegate-stress-test-2.ts
+```
+
+Both scripts spawn `pi --print` subprocesses directly (same as the extension) and measure success rate, latency, and memory. Adjust `CONCURRENCY_LEVELS`, `MODEL`, and `TIMEOUT_MS` constants at the top of each script.
+
+---
+
+## 14. Auto-activation
+
+The delegate extension **self-activates** on every session start via the `before_agent_start` event hook:
+
+```typescript
+pi.on("before_agent_start", async (event) => {
+  const active = pi.getActiveTools();
+  if (!active.includes("delegate")) {
+    pi.setActiveTools([...active, "delegate"]);
+  }
+  return { systemPrompt: `${event.systemPrompt}\n\n${HINT}` };
+});
+```
+
+This means:
+- **No manual `activate_tools` call needed** — delegate is available from the first message
+- **No config required** — works out of the box after dropping the extension file
+- **Belt and suspenders** — you can also add `"delegate"` to `additionalDefaultTools` in `.piclaw/config.json` for explicit config control
+
+```json
+// .piclaw/config.json
+{
+  "tools": {
+    "additionalDefaultTools": ["delegate"]
+  }
+}
+```
+
+### Recommended for other extensions
+
+If you create workspace extensions that should always be available, use this same pattern:
+
+```typescript
+pi.on("before_agent_start", async (event) => {
+  const active = pi.getActiveTools();
+  if (!active.includes("my_tool")) {
+    pi.setActiveTools([...active, "my_tool"]);
+  }
+  return {};
+});
+```
+
+This is more reliable than relying on `additionalDefaultTools` config alone, because the config may not take effect until a fresh session.
+
+```
+/workspace/.pi/
+├── extensions/
+│   └── delegate.ts              — Extension source (registers the delegate tool)
+├── skills/
+│   └── delegate/
+│       └── SKILL.md             — Agent skill (when/how to use delegate)
+```
+
+---
+
+## 15. Files
+
+```
+/workspace/.pi/
+├── extensions/
+│   └── delegate.ts              — Extension source (registers the delegate tool)
+├── skills/
+│   └── delegate/
+│       └── SKILL.md             — Agent skill (when/how to use delegate)
+```

--- a/addons/delegate/delegate.ts
+++ b/addons/delegate/delegate.ts
@@ -1,0 +1,514 @@
+/**
+ * delegate.ts — Delegate tasks to a different (typically cheaper/faster) model.
+ *
+ * Runs `pi --print --model <model> --tools <list>` as a subprocess with its own
+ * fresh context, captures the response, and returns it inline. The delegated
+ * agent has tool access so it can read files, run commands, grep, etc.
+ *
+ * The calling agent picks the model automatically based on the task — never
+ * choosing a model more capable than the one currently in use.
+ *
+ * Drop into .pi/extensions/ and /restart.
+ */
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { spawn as nodeSpawn } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const DEFAULT_TIMEOUT_SEC = 120;
+const MAX_OUTPUT_CHARS = 50_000;
+const MAX_TEXT_FILE_BYTES = 100_000; // 100KB limit for text file inlining
+const WORKSPACE_ROOT = "/workspace";
+
+// Extensions that should NOT be loaded in delegate (UI-only, recursive, or heavy)
+const EXCLUDED_EXTENSIONS = new Set([
+  "delegate.ts",           // prevent recursion
+  "kanban-board-widget.ts", // UI-only
+]);
+
+/**
+ * Discover the MCP adapter extension path.
+ * Cached after first call — result doesn't change during a session.
+ */
+let _mcpPathCache: string | null | undefined;
+function findMcpAdapter(): string | null {
+  if (_mcpPathCache !== undefined) return _mcpPathCache;
+  const candidates = [
+    join(process.env.BUN_INSTALL || "/usr/local/lib/bun", "install/global/node_modules/pi-mcp-adapter/index.ts"),
+    "/usr/local/lib/bun/install/global/node_modules/pi-mcp-adapter/index.ts",
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) { _mcpPathCache = p; return p; }
+  }
+  _mcpPathCache = null;
+  return null;
+}
+
+/**
+ * Discover workspace extensions safe to load in delegate.
+ * Cached after first call — extensions dir rarely changes mid-session.
+ */
+let _safeExtCache: string[] | undefined;
+function findSafeWorkspaceExtensions(): string[] {
+  if (_safeExtCache !== undefined) return _safeExtCache;
+  const extDir = "/workspace/.pi/extensions";
+  if (!existsSync(extDir)) { _safeExtCache = []; return []; }
+  try {
+    _safeExtCache = readdirSync(extDir)
+      .filter((f: string) => f.endsWith(".ts") && !EXCLUDED_EXTENSIONS.has(f))
+      .map((f: string) => join(extDir, f));
+    return _safeExtCache;
+  } catch {
+    _safeExtCache = [];
+    return [];
+  }
+}
+
+// ── Model tier system ──────────────────────────────────────────
+// Models ranked by capability tier. The delegate must pick a model
+// at or below the current model's tier.
+
+interface ModelTier {
+  id: string;
+  tier: number;
+  family: string;
+}
+
+// Models ranked by preference within each tier.
+// First match in a tier wins — order controls preference.
+const MODEL_TIERS: ModelTier[] = [
+  // Tier 1: legacy / cheapest
+  { id: "github-copilot/gpt-4o",                tier: 1, family: "gpt" },
+  { id: "github-copilot/gpt-4.1",               tier: 1, family: "gpt" },
+  { id: "github-copilot/claude-haiku-4.5",      tier: 1, family: "claude" },
+  { id: "github-copilot/grok-code-fast-1",      tier: 1, family: "grok" },
+  // Tier 2: fast & capable — the sweet spot for delegation
+  { id: "github-copilot/gpt-5.4-mini",          tier: 2, family: "gpt" },
+  { id: "github-copilot/gpt-5.1-codex-mini",    tier: 2, family: "gpt" },
+  { id: "github-copilot/gpt-5-mini",            tier: 2, family: "gpt" },
+  { id: "github-copilot/gemini-3-flash-preview", tier: 2, family: "gemini" },
+  // Tier 3: strong general-purpose
+  { id: "github-copilot/claude-sonnet-4.6",     tier: 3, family: "claude" },
+  { id: "github-copilot/claude-sonnet-4.5",     tier: 3, family: "claude" },
+  { id: "github-copilot/claude-sonnet-4",       tier: 3, family: "claude" },
+  { id: "github-copilot/gpt-5.4",               tier: 3, family: "gpt" },
+  { id: "github-copilot/gpt-5.2",               tier: 3, family: "gpt" },
+  { id: "github-copilot/gpt-5.1",               tier: 3, family: "gpt" },
+  { id: "github-copilot/gpt-5",                 tier: 3, family: "gpt" },
+  { id: "github-copilot/gemini-3.1-pro-preview", tier: 3, family: "gemini" },
+  { id: "github-copilot/gemini-3-pro-preview",   tier: 3, family: "gemini" },
+  { id: "github-copilot/gemini-2.5-pro",         tier: 3, family: "gemini" },
+  // Tier 4: codex — large context coding specialists
+  { id: "github-copilot/gpt-5.3-codex",         tier: 4, family: "gpt" },
+  { id: "github-copilot/gpt-5.2-codex",         tier: 4, family: "gpt" },
+  { id: "github-copilot/gpt-5.1-codex",         tier: 4, family: "gpt" },
+  { id: "github-copilot/gpt-5.1-codex-max",     tier: 4, family: "gpt" },
+  // Tier 5: frontier — deep reasoning, complex architecture
+  { id: "github-copilot/claude-opus-4.7",       tier: 5, family: "claude" },
+  { id: "github-copilot/claude-opus-4.6",       tier: 5, family: "claude" },
+  { id: "github-copilot/claude-opus-4.5",       tier: 5, family: "claude" },
+];
+
+// O(1) lookup by model ID
+const MODEL_TIER_MAP = new Map<string, ModelTier>(MODEL_TIERS.map((m) => [m.id, m]));
+
+function getModelTier(modelId: string): ModelTier | null {
+  return MODEL_TIER_MAP.get(modelId) ?? null;
+}
+
+function getCurrentTier(ctx: any): number {
+  const model = ctx?.model;
+  if (!model) return 3; // default to tier 3 if unknown
+  const fullId = `${model.provider}/${model.id}`;
+  const tier = getModelTier(fullId);
+  return tier?.tier ?? 3;
+}
+
+type TaskCategory = "quick" | "summarize" | "code" | "analyze" | "reason" | "judge";
+
+// Target tier per category — pick the best model AT this tier,
+// falling back to the nearest lower tier if maxTier is below target.
+const CATEGORY_TARGET_TIER: Record<TaskCategory, number> = {
+  quick: 2,      // gpt-5.4-mini sweet spot
+  summarize: 2,  // fast + decent comprehension
+  code: 3,       // needs strong reasoning
+  analyze: 3,    // needs strong reasoning
+  reason: 3,     // strong but NOT frontier — if you need frontier, don't delegate
+  judge: 3,      // independent review of main agent's output — different model family preferred
+};
+
+const VALID_CATEGORIES = new Set<TaskCategory>(["quick", "summarize", "code", "analyze", "reason", "judge"]);
+
+function selectModel(category: TaskCategory, maxTier: number, currentModelId?: string): string {
+  const candidates = MODEL_TIERS.filter((m) => m.tier <= maxTier);
+  if (candidates.length === 0) {
+    return "github-copilot/gpt-5.4-mini"; // consistent fallback
+  }
+
+  // Target tier for this category, capped by maxTier
+  const targetTier = Math.min(CATEGORY_TARGET_TIER[category] ?? 2, maxTier);
+
+  // For judge: prefer a different model family than the current agent
+  if (category === "judge" && currentModelId) {
+    const currentFamily = getModelTier(currentModelId)?.family;
+    if (currentFamily) {
+      const differentFamily = candidates.find(
+        (m) => m.tier === targetTier && m.family !== currentFamily
+      );
+      if (differentFamily) return differentFamily.id;
+      // Fall back to any different-family model at nearby tiers
+      for (let t = targetTier; t >= 1; t--) {
+        const fb = candidates.find((m) => m.tier === t && m.family !== currentFamily);
+        if (fb) return fb.id;
+      }
+    }
+  }
+
+  // Find the best candidate at target tier (first in list = preferred)
+  const atTarget = candidates.find((m) => m.tier === targetTier);
+  if (atTarget) return atTarget.id;
+
+  // Fall back: closest tier below target, then above
+  for (let t = targetTier - 1; t >= 1; t--) {
+    const fallback = candidates.find((m) => m.tier === t);
+    if (fallback) return fallback.id;
+  }
+
+  // Last resort: best available
+  return candidates[candidates.length - 1].id;
+}
+
+// ── Default tool sets per task profile ─────────────────────────
+
+const TOOL_PROFILES: Record<string, string> = {
+  read_only:  "read,grep,find,ls,mcp",
+  standard:   "read,grep,find,ls,bash,mcp",
+  full:       "read,grep,find,ls,bash,edit,write,mcp",
+};
+
+// Binary/image extensions that should be passed as @file args, not read as text
+const BINARY_EXTENSIONS = new Set([
+  ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif",
+  ".svg", ".ico",
+  ".pdf",
+  ".zip", ".tar", ".gz",
+  ".mp3", ".wav", ".mp4", ".webm",
+]);
+
+function isBinaryFile(filePath: string): boolean {
+  const ext = filePath.slice(filePath.lastIndexOf(".")).toLowerCase();
+  return BINARY_EXTENSIONS.has(ext);
+}
+
+/** Validate a resolved path: must be inside workspace, no control characters. */
+function validateFilePath(resolved: string, original: string): string | null {
+  // Check for control characters (shell injection prevention)
+  if (/[\x00-\x1f]/.test(resolved)) {
+    return `❌ Unsafe characters in path: ${original}`;
+  }
+  // Sandbox to workspace root
+  if (!resolved.startsWith(WORKSPACE_ROOT + "/") && resolved !== WORKSPACE_ROOT) {
+    return `❌ Path outside workspace: ${original} (resolved to ${resolved})`;
+  }
+  return null; // valid
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function result(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+// ── Extension ──────────────────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+  const HINT = [
+    "## Delegate tool",
+    "Use `delegate` to send a task to a cheaper/faster model and get the result inline.",
+    "Saves tokens by not loading the full conversation context into the delegated call.",
+    `Default model: \`github-copilot/gpt-5.4-mini\`. Override with the \`model\` parameter.`,
+    "Pass file paths in the `files` array to include file contents in the delegated prompt.",
+    "The delegate runs in a fresh context (no conversation history, no tools) — pure prompt → response.",
+    "Proactively delegate when a task is self-contained and doesn't need conversation history.",
+    "When the user asks to 'double check', 'verify', or 'review' your answer, use delegate with task_category='judge' to get a second opinion from a different model family.",
+  ].join("\n");
+
+  pi.on("before_agent_start", async (event) => {
+    // Auto-activate delegate tool so it's available without manual activate_tools
+    const active = pi.getActiveTools();
+    if (!active.includes("delegate")) {
+      pi.setActiveTools([...active, "delegate"]);
+    }
+    return { systemPrompt: `${event.systemPrompt}\n\n${HINT}` };
+  });
+
+  pi.registerTool({
+    name: "delegate",
+    label: "Delegate to Model",
+    description:
+      "Delegate a task to a cheaper/faster model in a fresh context. " +
+      "The delegate has its own tool access (read, grep, bash, etc.) but no conversation history. " +
+      "Use for: summarizing files, quick questions, code generation, data extraction, codebase exploration, " +
+      "or any task that doesn't require the full conversation context. " +
+      "The model is auto-selected based on the task category — never more capable than the current model.",
+    parameters: Type.Object({
+      prompt: Type.String({
+        description: "The task to delegate. Be specific — the delegate has no conversation history.",
+      }),
+      task_category: Type.Optional(
+        Type.Union([
+          Type.Literal("quick",     { description: "Fast/simple: formatting, extraction, translation, factual Q&A" }),
+          Type.Literal("summarize", { description: "Summarize files, notes, code, or text" }),
+          Type.Literal("code",      { description: "Code generation, refactoring, or mechanical edits" }),
+          Type.Literal("analyze",   { description: "Code review, architecture analysis, debugging" }),
+          Type.Literal("reason",    { description: "Complex reasoning, planning, multi-step logic" }),
+          Type.Literal("judge",     { description: "Review/critique the main agent's last response — uses a different model family" }),
+        ], {
+          description: "Task category for auto model selection. Default: summarize",
+        })
+      ),
+      model: Type.Optional(
+        Type.String({
+          description: "Explicit model override (provider/id). Skips auto-selection.",
+        })
+      ),
+      files: Type.Optional(
+        Type.Array(Type.String(), {
+          description: "File paths to include as context in the prompt.",
+        })
+      ),
+      tools: Type.Optional(
+        Type.Union([
+          Type.Literal("read_only", { description: "read, grep, find, ls, mcp" }),
+          Type.Literal("standard",  { description: "read, grep, find, ls, bash, mcp (default)" }),
+          Type.Literal("full",      { description: "read, grep, find, ls, bash, edit, write, mcp" }),
+          Type.String({ description: "Comma-separated tool names" }),
+        ], {
+          description: "Tool profile or explicit list. Default: standard (read, grep, find, ls, bash)",
+        })
+      ),
+      system_prompt: Type.Optional(
+        Type.String({
+          description: "Custom system prompt override.",
+        })
+      ),
+      timeout_sec: Type.Optional(
+        Type.Integer({
+          description: `Timeout in seconds. Default: ${DEFAULT_TIMEOUT_SEC}`,
+          minimum: 5,
+          maximum: 300,
+        })
+      ),
+    }),
+
+    async execute(_toolCallId, params, signal, _update, ctx) {
+      // #13: Validate category
+      const rawCategory = (params.task_category as TaskCategory) || "summarize";
+      const category: TaskCategory = VALID_CATEGORIES.has(rawCategory) ? rawCategory : "summarize";
+      const maxTier = getCurrentTier(ctx);
+
+      // Model selection
+      const currentModelId = ctx?.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+      const model = params.model || selectModel(category, maxTier, currentModelId);
+
+      const timeout = params.timeout_sec || DEFAULT_TIMEOUT_SEC;
+
+      // Resolve tools
+      const toolsArg = params.tools
+        ? (TOOL_PROFILES[params.tools] || params.tools)
+        : TOOL_PROFILES.standard;
+
+      // Separate files into text (inline in prompt) and binary (pass as @file args)
+      let fullPrompt = params.prompt;
+      const attachmentArgs: string[] = []; // @file args for binary/image files
+      let hasVisualInput = false;
+
+      if (params.files && params.files.length > 0) {
+        const textContents: string[] = [];
+        for (const filePath of params.files) {
+          const resolved = resolve(filePath);
+          // Security: validate path
+          const pathError = validateFilePath(resolved, filePath);
+          if (pathError) return result(pathError);
+          if (!existsSync(resolved)) {
+            return result(`❌ File not found: ${filePath}`);
+          }
+          if (isBinaryFile(filePath)) {
+            // Binary/image files: pass as @file positional arg to pi
+            attachmentArgs.push(`@${resolved}`);
+            hasVisualInput = true;
+          } else {
+            // Text files: inline in prompt (with size limit)
+            try {
+              const stat = statSync(resolved);
+              if (stat.size > MAX_TEXT_FILE_BYTES) {
+                return result(`❌ File too large for inlining: ${filePath} (${(stat.size / 1024).toFixed(0)}KB, max ${MAX_TEXT_FILE_BYTES / 1024}KB). Use the delegate's tools to read it instead.`);
+              }
+              const content = readFileSync(resolved, "utf-8");
+              textContents.push(`\n--- ${filePath} ---\n${content}\n---`);
+            } catch (err) {
+              return result(
+                `❌ Failed to read ${filePath}: ${err instanceof Error ? err.message : String(err)}`
+              );
+            }
+          }
+        }
+        if (textContents.length > 0) {
+          fullPrompt = `${fullPrompt}\n\nFile contents:${textContents.join("\n")}`;
+        }
+      }
+
+      // Modality-aware tier bumping: if visual input detected and target tier < 3, bump to 3
+      let effectiveModel = model;
+      if (hasVisualInput && !params.model) {
+        const modelTier = getModelTier(model);
+        if (modelTier && modelTier.tier < 3) {
+          // Override category to 'analyze' for visual input — forces tier 3 selection
+          effectiveModel = selectModel("analyze", maxTier, currentModelId);
+        }
+      }
+
+      // Build pi args (direct spawn, no shell wrapper)
+      const piArgs: string[] = [
+        "--print",
+        "--no-extensions",
+        "--model", effectiveModel,
+        "--tools", toolsArg,
+      ];
+
+      // Load MCP adapter + safe workspace extensions
+      const mcpPath = findMcpAdapter();
+      if (mcpPath) {
+        piArgs.push("-e", mcpPath);
+      }
+      for (const ext of findSafeWorkspaceExtensions()) {
+        piArgs.push("-e", ext);
+      }
+
+      // Append capability hints so cheap models know what tools are available
+      const capabilityHints = [
+        "Web search: run 'bun /workspace/.pi/skills/web-search/web-search.ts --query \"QUERY\" --fetch true --fetch-limit 3' to search the web.",
+        "Web search summary: run 'bun /workspace/.pi/skills/web-search-summary/web-search-summary.ts --query \"QUERY\"' for summarized results.",
+        "MCP: use the mcp tool with action 'call_tool' to call MCP server tools.",
+      ].join("\n");
+      piArgs.push("--append-system-prompt", capabilityHints);
+
+      if (params.system_prompt) {
+        piArgs.push("--system-prompt", params.system_prompt);
+      }
+
+      // Add @file args for binary/image attachments
+      for (const att of attachmentArgs) {
+        piArgs.push(att);
+      }
+
+      // Execute delegate subprocess (async with abort signal support)
+      try {
+        const { stdout, stderr, exitCode } = await runDelegateProcess(piArgs, fullPrompt, timeout, signal);
+
+        if (exitCode !== 0 && !stdout.trim()) {
+          const errMsg = stderr.trim() || `Process exited with code ${exitCode}`;
+          return result(`❌ Delegate failed (model: ${effectiveModel}): ${errMsg}`);
+        }
+
+        const trimmed = stdout.trim();
+        if (!trimmed) {
+          return result(`⚠️ Delegate returned empty response (model: ${effectiveModel}).`);
+        }
+
+        const truncated =
+          trimmed.length > MAX_OUTPUT_CHARS
+            ? trimmed.slice(0, MAX_OUTPUT_CHARS) + `\n\n[truncated at ${MAX_OUTPUT_CHARS} chars]`
+            : trimmed;
+
+        return result(`**Delegated to \`${effectiveModel}\` [${category}]:**\n\n${truncated}`);
+      } catch (err: any) {
+        if (err.name === "AbortError" || signal?.aborted) {
+          return result(`❌ Delegate aborted (model: ${effectiveModel}).`);
+        }
+        if (err.message?.includes("timed out")) {
+          return result(`❌ Delegate timed out after ${timeout}s (model: ${effectiveModel}).`);
+        }
+
+        return result(`❌ Delegate failed (model: ${effectiveModel}): ${err.message || String(err)}`);
+      }
+    },
+  });
+}
+
+/** Run pi directly as a child process with stdin prompt, abort + timeout support. */
+function runDelegateProcess(
+  piArgs: string[],
+  prompt: string,
+  timeoutSec: number,
+  signal?: AbortSignal | undefined,
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = nodeSpawn("pi", piArgs, {
+      cwd: "/workspace",
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // Cap buffered output to prevent memory blowup
+    const MAX_BUFFER = MAX_OUTPUT_CHARS * 2;
+    child.stdout?.on("data", (chunk: Buffer) => {
+      if (stdout.length < MAX_BUFFER) stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      if (stderr.length < MAX_BUFFER) stderr += chunk.toString();
+    });
+
+    // Write prompt to stdin and close it
+    child.stdin?.write(prompt);
+    child.stdin?.end();
+
+    function cleanup() {
+      clearTimeout(timer);
+      if (killTimer) { clearTimeout(killTimer); killTimer = null; }
+      signal?.removeEventListener("abort", onAbort);
+    }
+
+    function killChild(reason: Error) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      try { child.kill("SIGTERM"); } catch {}
+      killTimer = setTimeout(() => { try { child.kill("SIGKILL"); } catch {} }, 3000);
+      reject(reason);
+    }
+
+    // Timeout
+    const timer = setTimeout(() => {
+      killChild(new Error(`timed out after ${timeoutSec}s`));
+    }, timeoutSec * 1000);
+
+    // Abort signal
+    const onAbort = () => {
+      const err = new Error("Aborted"); err.name = "AbortError";
+      killChild(err);
+    };
+    if (signal?.aborted) { onAbort(); return; }
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve({ stdout, stderr, exitCode: code });
+    });
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err);
+    });
+  });
+}

--- a/addons/delegate/index.ts
+++ b/addons/delegate/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./delegate";

--- a/addons/delegate/package.json
+++ b/addons/delegate/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "piclaw-addon-delegate",
+  "version": "0.1.0",
+  "description": "Delegate tasks to cheaper/faster models with auto model selection, tool access, and MCP support",
+  "type": "module",
+  "main": "index.ts",
+  "piclaw": {
+    "type": "extension",
+    "compatibleVersions": ">=1.8.0",
+    "tags": ["delegation", "multi-model", "cost-optimization"],
+    "skills": ["skills/delegate"]
+  },
+  "agents": {
+    "skills": [
+      { "name": "delegate", "path": "./skills/delegate" }
+    ]
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": ">=0.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@mariozechner/pi-coding-agent": { "optional": true }
+  },
+  "dependencies": {
+    "@sinclair/typebox": ">=0.30.0"
+  },
+  "license": "MIT"
+}

--- a/addons/delegate/skills/delegate/SKILL.md
+++ b/addons/delegate/skills/delegate/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: delegate
+description: Delegate tasks to a cheaper/faster model to save tokens. Use when a task doesn't need the full conversation context.
+distribution: public
+---
+
+# Delegate
+
+Use the `delegate` tool to offload work to a cheaper/faster model in a fresh context. The delegate has its own tools (read, grep, bash, MCP) but no conversation history — saving tokens.
+
+## When to delegate
+
+- **File summaries** — "summarize this 500-line file" costs the full file in YOUR context; delegate reads it in ITS context instead
+- **Quick lookups** — factual questions, counting, listing, formatting
+- **Web search** — delegate has MCP + web-search skill access
+- **Code generation** — mechanical/boilerplate code that doesn't need conversation context
+- **Data extraction** — pull specific info from files without loading them into your context
+- **Exploration** — "find all files matching X" or "what does this module do"
+
+## When NOT to delegate
+
+- Task needs conversation history or prior context
+- Task requires multiple back-and-forth turns
+- Task needs the user to see intermediate steps
+- Task is already simple enough to do directly (one grep, one read)
+
+## Key principle
+
+Delegate when the task is **self-contained** — describable in a single prompt without needing "you remember when we discussed X."
+
+## Usage
+
+```
+delegate({
+  prompt: "Summarize the key concepts in this file",
+  files: ["notes/piclaw-sessions.md"],
+  task_category: "summarize"
+})
+```
+
+### Task categories
+
+| Category | When | Model tier |
+|---|---|---|
+| `quick` | Formatting, factual Q&A, translation | Tier 2 (gpt-5.4-mini) |
+| `summarize` | File/note/code summaries | Tier 2 (gpt-5.4-mini) |
+| `code` | Code gen, refactoring, boilerplate | Tier 3 (sonnet-4.6) |
+| `analyze` | Code review, architecture, debugging | Tier 3 (sonnet-4.6) |
+| `reason` | Complex logic, multi-step | Tier 3 (sonnet-4.6) — if you need frontier, don't delegate |
+| `judge` | Review/critique agent's last response | Tier 3, **different model family** than current |
+
+## Judge mode
+
+When the user says "double check", "verify", "review your answer", "second opinion", or similar:
+
+1. Capture your last response text
+2. Delegate with `task_category: "judge"` and include your response in the prompt
+3. The judge model is automatically chosen from a **different family** (if you're Claude, judge will be GPT, and vice versa)
+
+Example:
+```
+delegate({
+  prompt: "Review this response for accuracy, completeness, and potential issues:\n\n<response>\n[paste last response here]\n</response>\n\nBe critical. Flag anything wrong, missing, or misleading.",
+  task_category: "judge"
+})
+```
+
+### Tool profiles
+
+| Profile | Tools | When |
+|---|---|---|
+| `read_only` | read, grep, find, ls, mcp | Safe exploration only |
+| `standard` | read, grep, find, ls, bash, mcp | Most tasks (default) |
+| `full` | read, grep, find, ls, bash, edit, write, mcp | Needs to write files |
+
+## Prompt tips
+
+The delegate has **no conversation history**. Write self-contained prompts:
+
+- ❌ "Summarize that file we were looking at"
+- ✅ "Summarize /workspace/notes/piclaw-sessions.md in 3 bullets"
+
+- ❌ "Fix the bug"
+- ✅ "Read /workspace/.pi/extensions/delegate.ts and check for any shell escaping issues"
+
+Include file paths explicitly. Give clear output format instructions.

--- a/catalog.json
+++ b/catalog.json
@@ -9,8 +9,14 @@
       "type": "extension",
       "description": "Autonomous experiment loop sub-agent (start/stop/status tools via tmux)",
       "path": "addons/autoresearch",
-      "tags": ["experiments", "research", "automation"],
-      "skills": ["autoresearch-create"]
+      "tags": [
+        "experiments",
+        "research",
+        "automation"
+      ],
+      "skills": [
+        "autoresearch-create"
+      ]
     },
     {
       "slug": "code-validator",
@@ -19,7 +25,11 @@
       "type": "extension",
       "description": "Diagnostics tool for code validation (Python, JS/TS, JSON, extensible via validators.json)",
       "path": "addons/code-validator",
-      "tags": ["diagnostics", "validation", "linting"],
+      "tags": [
+        "diagnostics",
+        "validation",
+        "linting"
+      ],
       "skills": []
     },
     {
@@ -29,7 +39,11 @@
       "type": "extension",
       "description": "Developer tools for workspace diagnostics and environment inspection",
       "path": "addons/dev-tools",
-      "tags": ["developer", "diagnostics", "environment"],
+      "tags": [
+        "developer",
+        "diagnostics",
+        "environment"
+      ],
       "skills": []
     },
     {
@@ -39,8 +53,29 @@
       "type": "extension",
       "description": "Interactive kanban board dashboard widget for the web timeline",
       "path": "addons/kanban-board-widget",
-      "tags": ["ui", "kanban", "widget", "dashboard"],
+      "tags": [
+        "ui",
+        "kanban",
+        "widget",
+        "dashboard"
+      ],
       "skills": []
+    },
+    {
+      "slug": "delegate",
+      "name": "piclaw-addon-delegate",
+      "version": "0.1.0",
+      "type": "extension",
+      "description": "Delegate tasks to cheaper/faster models with auto model selection, tool access, and MCP support",
+      "path": "addons/delegate",
+      "tags": [
+        "delegation",
+        "multi-model",
+        "cost-optimization"
+      ],
+      "skills": [
+        "delegate"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add the **delegate** extension as a new community addon. It lets agents send tasks to a cheaper/faster model in a fresh context, saving tokens and enabling multi-model workflows.

## Features

- **Auto model selection** — picks the best model for the task category, never exceeding the current model tier
- **6 task categories** — quick, summarize, code, analyze, reason, judge
- **Tool access** — delegates get read, grep, find, ls, bash, MCP tools
- **Multimodal** — images/PDFs passed as native attachments with automatic tier bumping
- **Judge mode** — cross-family second opinion for reviewing agent responses
- **Fresh context** — no conversation history, saves tokens

## Files added

| File | Purpose |
|------|---------|
| `addons/delegate/index.ts` | Entry point (re-export shim) |
| `addons/delegate/delegate.ts` | Extension implementation |
| `addons/delegate/package.json` | Addon manifest (piclaw + agentskills.io dual fields) |
| `addons/delegate/skills/delegate/SKILL.md` | Skill instructions |
| `addons/delegate/README.md` | User-facing documentation |
| `addons/delegate/REFERENCE.md` | Full API reference |
| `catalog.json` | Updated with delegate entry |
| `README.md` | Updated available addons table |

## Testing

Stress tested on 12-core / 7.5GB container (github-copilot provider):
- **100% success rate** up to 30 concurrent calls
- Avg latency 2.4–3.8s depending on concurrency
- Memory overhead < 14MB at peak

## Model selection matrix

| Category | Model picked | Use for |
|---|---|---|
| `quick` | gpt-5.4-mini (tier 2) | Formatting, factual Q&A, translation |
| `summarize` | gpt-5.4-mini (tier 2) | File/note/code summaries |
| `code` | claude-sonnet-4.6 (tier 3) | Code gen, refactoring |
| `analyze` | claude-sonnet-4.6 (tier 3) | Code review, debugging |
| `reason` | claude-sonnet-4.6 (tier 3) | Complex logic |
| `judge` | Different family (tier 3) | Second opinion, verify |
