### PR TITLE
fix(ast-grep-tool): refine skill — add examples, workflow, safety checks

### DIFF
--- a/addons/ast-grep-tool/package.json
+++ b/addons/ast-grep-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcarmo/piclaw-addon-ast-grep",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Structural code search and rewrite using ast-grep as a native LLM tool",
   "type": "module",
   "main": "index.ts",

--- a/addons/ast-grep-tool/skills/ast-grep/SKILL.md
+++ b/addons/ast-grep-tool/skills/ast-grep/SKILL.md
@@ -7,21 +7,36 @@ description: Use `code_search` and `code_rewrite` for syntax-aware code search a
 
 Use this skill when text search would be noisy or unsafe.
 
-## Use when
+## Tools
+- `code_search(pattern, lang, path?, limit?)` — find code by AST pattern
+- `code_rewrite(pattern, rewrite, lang, path?, dry_run?)` — structural find-and-replace
 
-- Matching code by shape: calls, imports, declarations, empty blocks, missing branches
-- Applying the same structural rewrite across files
-- Auditing or banning specific code patterns
+## Examples
+- `console.log($MSG)` — find all console.log calls
+- `var $NAME = $VAL` → `const $NAME = $VAL` — modernize var declarations
+- `catch ($ERR) { }` — find empty catch blocks
+- `import $X from "lodash"` — find imports from a specific module
+
+## Workflow
+1. `code_search(pattern, lang, path, limit=20)` — narrow path, sample first
+2. Inspect matches — verify pattern catches what you want
+3. `code_rewrite(pattern, rewrite, lang, path, dry_run=true)` — preview changes
+4. Review the dry run output
+5. `code_rewrite(pattern, rewrite, lang, path, dry_run=false)` — apply
+6. Read changed files, run formatting/tests
 
 ## Prefer other tools when
+- You need plain text, comments, or strings → `grep`
+- You need type/symbol-aware results → LSP/symbol tools if available
 
-- You need plain text, comments, or strings → `rg`
-- You need type/symbol-aware results → `lsp_references` or other LSP tools
+## Safety
+- Always run `dry_run=true` before applying any rewrite
+- Scope with `path` to avoid unintended matches in vendored/generated code
+- Supported `lang` values: typescript, javascript, tsx, jsx, python, rust, go, java, c, cpp, csharp, ruby, swift, kotlin, lua, html, css, json, yaml
+- After applying rewrites, read changed files and run tests/formatting before moving on
 
-## Working rules
-
-- Choose the exact target language; run separate passes for `typescript`/`tsx`, `javascript`/`jsx`, etc.
-- Start with `code_search` on a narrow `path`, then use `code_rewrite` in `dry_run`, then apply.
-- Keep patterns minimal and valid in the target language; if a pattern fails, simplify and build up.
-- Matches are syntax-aware, not semantic: identical code shapes across different symbols can still match.
-- After applying rewrites, run diagnostics/tests/formatting.
+## Troubleshooting
+- No matches: verify `lang` is correct (e.g. `typescript` not `ts`), broaden pattern
+- Too many matches: narrow `path`, add more structure to pattern, lower `limit`
+- Pattern error: simplify — patterns must be valid syntax in the target language
+- Wrong language: `typescript` ≠ `tsx`, `javascript` ≠ `jsx` — run separate passes

--- a/catalog.json
+++ b/catalog.json
@@ -5,7 +5,7 @@
     {
       "slug": "ast-grep-tool",
       "name": "@rcarmo/piclaw-addon-ast-grep",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "type": "extension",
       "description": "Structural code search and rewrite using ast-grep as a native LLM tool",
       "path": "addons/ast-grep-tool",
@@ -17,7 +17,7 @@
       "skills": [],
       "install": {
         "kind": "tarball",
-        "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-ast-grep-0.1.1.tgz"
+        "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-ast-grep-0.1.2.tgz"
       },
       "updatedAt": "2026-04-28",
       "owner": {


### PR DESCRIPTION
Updates ast-grep-tool to v0.1.2. Adds tool signatures, examples, workflow steps, troubleshooting, and safety section to SKILL.md. Catalog regenerated and type-checked.