### PR TITLE
feat: add git-query-tools addon

### DIFF
--- a/addons/git-query-tools/constants.ts
+++ b/addons/git-query-tools/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * constants.ts — Shared constants for git-query-tools extension.
+ */
+
+export const encoder = new TextEncoder();
+export const DEFAULT_MAX_LINES = 200;
+export const DEFAULT_MAX_BYTES = 51200;
+export const DEFAULT_TIMEOUT = 30_000;
+export const FAST_TIMEOUT = 10_000;
+export const MAX_PROCESS_OUTPUT = 10 * 1024 * 1024;
+export const BASE_DIR = "/workspace";

--- a/addons/git-query-tools/index.ts
+++ b/addons/git-query-tools/index.ts
@@ -1,0 +1,8 @@
+/**
+ * index.ts — Entry point for git-query-tools extension.
+ *
+ * Re-exports the default supervisor function so that piclaw can load
+ * this folder as a single extension module.
+ */
+
+export { default } from "./supervisor.js";

--- a/addons/git-query-tools/output.ts
+++ b/addons/git-query-tools/output.ts
@@ -1,0 +1,69 @@
+/**
+ * output.ts — Output collection and JSON envelope helpers for git-query-tools.
+ */
+
+import type { CollectResult, ToolEnvelope, ToolMeta } from "./types.js";
+import { encoder, DEFAULT_MAX_LINES, DEFAULT_MAX_BYTES } from "./constants.js";
+
+export function stripTrailing(s: string): string {
+  let end = s.length;
+  while (end > 0 && (s[end - 1] === "\n" || s[end - 1] === "\r")) end--;
+  return end === s.length ? s : s.slice(0, end);
+}
+
+export function collectOutput(
+  stdout: string,
+  maxLines = DEFAULT_MAX_LINES,
+  maxBytes = DEFAULT_MAX_BYTES,
+): CollectResult {
+  const cleaned = stripTrailing(stdout);
+  if (!cleaned) return { output: "", totalLines: 0, totalBytes: 0, truncated: false };
+  const allLines = cleaned.split("\n");
+  const totalLines = allLines.length;
+  const totalBytes = encoder.encode(cleaned).length;
+  let output = cleaned;
+  let truncated = false;
+  if (allLines.length > maxLines) {
+    output = allLines.slice(0, maxLines).join("\n");
+    truncated = true;
+  }
+  if (encoder.encode(output).length > maxBytes) {
+    const lines = output.split("\n");
+    let safe = "";
+    let safeBytes = 0;
+    for (const line of lines) {
+      const lineBytes = encoder.encode(line).length;
+      const sep = safe ? 1 : 0; // newline separator byte
+      if (safeBytes + sep + lineBytes > maxBytes) break;
+      safe = safe ? safe + "\n" + line : line;
+      safeBytes += sep + lineBytes;
+    }
+    output = safe;
+    truncated = true;
+  }
+  return { output, totalLines, totalBytes, truncated };
+}
+
+export function envelope(e: ToolEnvelope): string {
+  const o: ToolEnvelope = { tool: e.tool, status: e.status, summary: e.summary };
+  if (e.content !== undefined) o.content = e.content;
+  if (e.warnings?.length) o.warnings = e.warnings;
+  if (e.meta && Object.keys(e.meta).length > 0) o.meta = e.meta;
+  return JSON.stringify(o, null, 2);
+}
+
+export function ok(
+  tool: string,
+  summary: string,
+  opts: { content?: string; warnings?: string[]; meta?: ToolMeta } = {},
+): string {
+  return envelope({ tool, status: "ok", summary, ...opts });
+}
+
+export function err(
+  tool: string,
+  summary: string,
+  opts: { content?: string; warnings?: string[]; meta?: ToolMeta } = {},
+): string {
+  return envelope({ tool, status: "error", summary, ...opts });
+}

--- a/addons/git-query-tools/package.json
+++ b/addons/git-query-tools/package.json
@@ -16,6 +16,11 @@
       "skills/git-query-tools"
     ]
   },
+  "agents": {
+    "skills": [
+      { "name": "git-query-tools", "path": "skills/git-query-tools/SKILL.md" }
+    ]
+  },
   "pi": {
     "extensions": [
       "index.ts"

--- a/addons/git-query-tools/package.json
+++ b/addons/git-query-tools/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@rcarmo/piclaw-addon-git-query-tools",
+  "version": "0.1.0",
+  "description": "Git history and JSON query tools for piclaw agents",
+  "type": "module",
+  "main": "index.ts",
+  "piclaw": {
+    "type": "extension",
+    "compatibleVersions": ">=1.8.0",
+    "tags": [
+      "git",
+      "json",
+      "query"
+    ],
+    "skills": [
+      "skills/git-query-tools"
+    ]
+  },
+  "pi": {
+    "extensions": [
+      "index.ts"
+    ],
+    "skills": [
+      "skills"
+    ]
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*",
+    "@sinclair/typebox": "*"
+  },
+  "license": "MIT",
+  "publishConfig": { "registry": "https://npm.pkg.github.com", "access": "public" },
+  "keywords": [
+    "piclaw",
+    "piclaw-addon"
+  ]
+}

--- a/addons/git-query-tools/process.ts
+++ b/addons/git-query-tools/process.ts
@@ -1,0 +1,97 @@
+/**
+ * process.ts — Subprocess runner with output capping for git-query-tools.
+ */
+
+import type { SpawnResult } from "./types.js";
+import { MAX_PROCESS_OUTPUT } from "./constants.js";
+
+export async function readCapped(
+  stream: ReadableStream<Uint8Array> | null,
+  maxBytes: number,
+  onCap?: () => void,
+): Promise<{ text: string; capped: boolean }> {
+  if (!stream) return { text: "", capped: false };
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let capped = false;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done || !value) break;
+      total += value.length;
+      if (total > maxBytes) {
+        const excess = total - maxBytes;
+        chunks.push(value.slice(0, value.length - excess));
+        capped = true;
+        onCap?.();
+        break;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const merged = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return { text: new TextDecoder().decode(merged), capped };
+}
+
+export async function runProcess(
+  cmd: string[],
+  opts: { cwd?: string; stdin?: Blob; timeout: number; signal?: AbortSignal },
+): Promise<SpawnResult> {
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = Bun.spawn(cmd, {
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: opts.timeout,
+      killSignal: "SIGKILL",
+      cwd: opts.cwd,
+      stdin: opts.stdin,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      stdout: "",
+      stderr: `Failed to spawn '${cmd[0]}': ${msg}`,
+      exitCode: 127,
+      signalCode: null,
+    };
+  }
+
+  if (opts.signal) {
+    const abort = () => {
+      try { proc.kill("SIGKILL"); } catch {}
+    };
+    if (opts.signal.aborted) { abort(); }
+    else { opts.signal.addEventListener("abort", abort, { once: true }); }
+    // Remove the listener after the process exits normally to prevent a leak
+    proc.exited.then(() => opts.signal!.removeEventListener("abort", abort)).catch(() => {});
+  }
+
+  const killOnCap = () => {
+    try { proc.kill("SIGKILL"); } catch {}
+  };
+  const [stdoutR, stderrR] = await Promise.all([
+    readCapped(proc.stdout as ReadableStream<Uint8Array>, MAX_PROCESS_OUTPUT, killOnCap),
+    readCapped(proc.stderr as ReadableStream<Uint8Array>, MAX_PROCESS_OUTPUT, killOnCap),
+  ]);
+  await proc.exited;
+
+  let stderr = stderrR.text;
+  if (stdoutR.capped) stderr = `[stdout capped at ${MAX_PROCESS_OUTPUT / 1024 / 1024}MB] ${stderr}`;
+  if (stderrR.capped) stderr = `[stderr capped at ${MAX_PROCESS_OUTPUT / 1024 / 1024}MB] ${stderr}`;
+
+  return {
+    stdout: stdoutR.text,
+    stderr,
+    exitCode: proc.exitCode,
+    signalCode: proc.signalCode as string | null,
+  };
+}

--- a/addons/git-query-tools/skills/git-query-tools/SKILL.md
+++ b/addons/git-query-tools/skills/git-query-tools/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: git-query-tools
+description: git_history and json_query tools for structured git log exploration and jq-style JSON querying.
+distribution: public
+---
+
+# Git Query Tools
+
+Two workspace tools for structured data queries.
+
+## git_history
+
+Prefer over raw `git log` commands. Returns structured JSON with truncation.
+
+```
+git_history({ mode: "log", limit: 10 })              # recent commits
+git_history({ mode: "search", query: "fix bug" })     # search commit messages
+git_history({ mode: "code-search", query: "TODO" })   # search code history
+git_history({ mode: "blame", file: "path/to/file" })  # file blame
+```
+
+## json_query
+
+Prefer over shell `jq` piping. Validates expressions and returns structured output.
+
+```
+json_query({ file: "data.json", query: ".items[] | .name" })
+json_query({ input: '{"a":1}', query: ".a" })
+```

--- a/addons/git-query-tools/supervisor.ts
+++ b/addons/git-query-tools/supervisor.ts
@@ -1,0 +1,288 @@
+/**
+ * supervisor.ts — Tool registration for git_history and json_query.
+ *
+ * Registers both tools with the Pi ExtensionAPI, wiring up schemas,
+ * validation, and execute handlers.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { extname } from "node:path";
+
+import { ok, err, collectOutput, stripTrailing } from "./output.js";
+import { runProcess } from "./process.js";
+import { safePath, relPath, validateText, checkJqExpression, parseBlameLines } from "./validation.js";
+import { BASE_DIR, DEFAULT_TIMEOUT, FAST_TIMEOUT } from "./constants.js";
+
+function result(text: string) {
+  return { content: [{ type: "text" as const, text }], details: {} };
+}
+
+/* ── git_history ──────────────────────────────────────────────────── */
+
+const TOOL_GIT = "git-history";
+
+async function runGit(args: string[], mode: string, signal?: AbortSignal) {
+  const { stdout, stderr, exitCode, signalCode } = await runProcess(
+    ["git", ...args],
+    { cwd: BASE_DIR, timeout: DEFAULT_TIMEOUT, signal },
+  );
+  if (signalCode) {
+    return err(TOOL_GIT, "History query was killed", {
+      meta: { mode, signal: signalCode, timedOut: signalCode === "SIGKILL", timeoutMs: DEFAULT_TIMEOUT },
+    });
+  }
+  if (exitCode !== 0) {
+    return err(
+      TOOL_GIT,
+      stripTrailing(stderr) || stripTrailing(stdout) || `git exited with code ${exitCode}`,
+      { meta: { mode, exitCode: exitCode ?? -1 } },
+    );
+  }
+  const raw = stripTrailing(stdout);
+  if (!raw) {
+    return ok(TOOL_GIT, "No results found", { meta: { mode, resultCount: 0, truncated: false } });
+  }
+  const { output, totalLines, totalBytes, truncated } = collectOutput(raw);
+  return ok(TOOL_GIT, truncated ? "Results truncated" : "Results returned", {
+    content: output,
+    meta: { mode, totalLines, totalBytes, truncated },
+  });
+}
+
+/* ── json_query ───────────────────────────────────────────────────── */
+
+const TOOL_JQ = "json-query";
+
+/* ── Extension export ─────────────────────────────────────────────── */
+
+export default function (pi: ExtensionAPI) {
+  const gitCheck = Bun.spawnSync(["which", "git"]);
+  const jqCheck = Bun.spawnSync(["which", "jq"]);
+  if (gitCheck.exitCode !== 0 || jqCheck.exitCode !== 0) {
+    console.warn("[git-query-tools] git or jq not found");
+  }
+
+  /* git_history */
+  pi.registerTool({
+    name: "git_history",
+    label: "Git History",
+    description:
+      "Inspect git history: commits, code-history searches, commit-message searches, and blame. Prefer over raw git commands for structured history queries with truncation. Returns JSON envelope.",
+    parameters: Type.Object({
+      mode: Type.Union(
+        [
+          Type.Literal("log"),
+          Type.Literal("content_search"),
+          Type.Literal("message_search"),
+          Type.Literal("blame"),
+        ],
+        { description: "log=recent commits, content_search=string-in-diff, message_search=commit message search, blame=file blame" },
+      ),
+      query: Type.Optional(Type.String({ description: "Required for content_search and message_search" })),
+      file: Type.Optional(Type.String({ description: "File path (relative or absolute). Required for blame." })),
+      max_count: Type.Optional(Type.Number({ description: "Max commits (default 20)" })),
+      author: Type.Optional(Type.String({ description: "Author name/email pattern" })),
+      since: Type.Optional(Type.String({ description: "Git date filter, e.g. '2024-01-01'" })),
+      diff: Type.Optional(Type.Boolean({ description: "Include patch output (not in blame)" })),
+      lines: Type.Optional(Type.String({ description: "Line range for blame: '10', '10,20', '10:20'" })),
+      all: Type.Optional(Type.Boolean({ description: "Search all branches (cannot combine with ref)" })),
+      ref: Type.Optional(Type.String({ description: "Branch/tag/ref to search" })),
+    }),
+    async execute(_id, params, signal) {
+      type P = typeof params;
+      const p = params as P;
+
+      const checks = [
+        validateText(p.query, "query"),
+        validateText(p.file, "file"),
+        validateText(p.author, "author"),
+        validateText(p.since, "since"),
+        validateText(p.ref, "ref"),
+      ];
+      for (const e of checks) if (e) return result(err(TOOL_GIT, e));
+
+      if (p.ref !== undefined && p.ref.trimStart().startsWith("-"))
+        return result(err(TOOL_GIT, "'ref' must not start with '-'"));
+
+      if (p.max_count !== undefined && (!Number.isInteger(p.max_count) || p.max_count < 1))
+        return result(err(TOOL_GIT, "'max_count' must be a positive integer"));
+      if (p.all && p.ref) return result(err(TOOL_GIT, "choose either 'all' or 'ref', not both"));
+      if (p.mode === "blame" && p.diff) return result(err(TOOL_GIT, "'diff' not supported in blame"));
+      if (p.mode !== "blame" && p.lines) return result(err(TOOL_GIT, "'lines' only for blame mode"));
+
+      if (p.file) {
+        const { error } = safePath(p.file);
+        if (error) return result(err(TOOL_GIT, error));
+      }
+
+      const maxCount = p.max_count ?? 20;
+      const common = [`--max-count=${maxCount}`, "--format=%h %ad %an | %s", "--date=short"];
+      if (p.author) common.push(`--author=${p.author.trim()}`);
+      if (p.since) common.push(`--since=${p.since.trim()}`);
+
+      switch (p.mode) {
+        case "log": {
+          const args = ["log", ...common, ...(p.all ? ["--all"] : p.ref ? [p.ref.trim()] : [])];
+          if (p.diff) args.push("-p");
+          if (p.file) args.push("--follow", "--", relPath(p.file.trim()));
+          return result(await runGit(args, "log", signal));
+        }
+        case "content_search": {
+          if (!p.query) return result(err(TOOL_GIT, "'query' required for content_search"));
+          const args = ["log", `-S${p.query.trim()}`, ...common, ...(p.all ? ["--all"] : p.ref ? [p.ref.trim()] : [])];
+          if (p.diff) args.push("-p");
+          if (p.file) args.push("--follow", "--", relPath(p.file.trim()));
+          return result(await runGit(args, "content_search", signal));
+        }
+        case "message_search": {
+          if (!p.query) return result(err(TOOL_GIT, "'query' required for message_search"));
+          const args = ["log", `--grep=${p.query.trim()}`, ...common, ...(p.all ? ["--all"] : p.ref ? [p.ref.trim()] : [])];
+          if (p.diff) args.push("-p");
+          if (p.file) args.push("--follow", "--", relPath(p.file.trim()));
+          return result(await runGit(args, "message_search", signal));
+        }
+        case "blame": {
+          if (!p.file) return result(err(TOOL_GIT, "'file' required for blame"));
+          const resolved = relPath(p.file.trim());
+          const args = ["blame", "--date=short"];
+          const { normalized, error: lineErr } = parseBlameLines(p.lines);
+          if (lineErr) return result(err(TOOL_GIT, lineErr));
+          if (normalized) args.push(`-L${normalized}`);
+          if (p.ref) args.push(p.ref.trim());
+          args.push("--", resolved);
+          return result(await runGit(args, "blame", signal));
+        }
+      }
+      return result(err(TOOL_GIT, `Unknown mode: ${p.mode}`));
+    },
+  });
+
+  /* json_query */
+  pi.registerTool({
+    name: "json_query",
+    label: "JSON Query",
+    description:
+      "Extract, filter, and reshape JSON data with jq expressions. Prefer over shell-based filtering for clearer validation. Returns JSON envelope.",
+    parameters: Type.Object({
+      expression: Type.Optional(Type.String({ description: "jq expression (required unless keys_only)" })),
+      file: Type.Optional(Type.String({ description: "Path to JSON file (mutually exclusive with input)" })),
+      input: Type.Optional(Type.String({ description: "Inline JSON string (mutually exclusive with file)" })),
+      raw_output: Type.Optional(Type.Boolean({ description: "Output raw strings without JSON quotes" })),
+      slurp: Type.Optional(Type.Boolean({ description: "Read entire input into array" })),
+      compact: Type.Optional(Type.Boolean({ description: "Compact output" })),
+      keys_only: Type.Optional(Type.Boolean({ description: "List root-level keys (overrides expression)" })),
+    }),
+    async execute(_id, params, signal) {
+      type P = typeof params;
+      const p = params as P;
+
+      const exprErr = p.expression !== undefined && !p.expression.trim() ? "'expression' cannot be empty" : undefined;
+      if (exprErr) return result(err(TOOL_JQ, exprErr));
+      const fileErr = validateText(p.file, "file");
+      if (fileErr) return result(err(TOOL_JQ, fileErr));
+      const inputErr = p.input !== undefined && !p.input.trim() ? "'input' cannot be empty" : undefined;
+      if (inputErr) return result(err(TOOL_JQ, inputErr));
+
+      const hasFile = typeof p.file === "string";
+      const hasInput = typeof p.input === "string";
+      if (hasFile === hasInput) return result(err(TOOL_JQ, "exactly one of file or input must be provided"));
+
+      let resolvedPath: string | undefined;
+      if (hasFile) {
+        const { resolved, error } = safePath(p.file!);
+        if (error) return result(err(TOOL_JQ, error));
+        resolvedPath = resolved;
+      }
+
+      const expressionOverridden = p.keys_only && p.expression;
+      const expression = p.keys_only ? "keys" : p.expression?.trim();
+      if (!expression) return result(err(TOOL_JQ, "expression is required (unless keys_only is true)"));
+
+      const blocked = checkJqExpression(expression);
+      if (blocked) return result(err(TOOL_JQ, blocked));
+
+      const flags: string[] = [];
+      if (p.raw_output) flags.push("-r");
+      if (p.slurp) flags.push("-s");
+      if (p.compact) flags.push("-c");
+      flags.push("-e");
+
+      const cmd = resolvedPath
+        ? ["jq", ...flags, "--", expression, resolvedPath]
+        : ["jq", ...flags, "--", expression];
+      const stdinBlob = resolvedPath ? undefined : new Blob([p.input!.trim()]);
+
+      const { stdout, stderr, exitCode, signalCode } = await runProcess(cmd, {
+        stdin: stdinBlob,
+        timeout: FAST_TIMEOUT,
+        signal,
+      });
+
+      const warnings = expressionOverridden
+        ? [`keys_only=true ignored expression '${p.expression?.trim()}'`]
+        : undefined;
+
+      if (signalCode) {
+        return result(
+          err(TOOL_JQ, "Query killed", {
+            meta: { signal: signalCode, timedOut: signalCode === "SIGKILL", timeoutMs: FAST_TIMEOUT },
+          }),
+        );
+      }
+
+      if ((exitCode === 1 || exitCode === 4) && !stderr.trim()) {
+        const raw = stripTrailing(stdout);
+        if (raw) {
+          const { output, totalLines, totalBytes, truncated } = collectOutput(raw);
+          const label = exitCode === 1 ? "false/null result" : "empty result";
+          return result(
+            ok(TOOL_JQ, `Query completed with ${label}`, {
+              content: output,
+              warnings,
+              meta: { totalLines, totalBytes, truncated, expressionOverridden: Boolean(expressionOverridden) },
+            }),
+          );
+        }
+        return result(
+          ok(TOOL_JQ, exitCode === 1 ? "Result was false or null" : "Empty result set", {
+            warnings,
+            meta: { expressionOverridden: Boolean(expressionOverridden), truncated: false },
+          }),
+        );
+      }
+
+      if (exitCode !== 0) {
+        const msg = stderr.trim() || `exit code ${exitCode}`;
+        if (resolvedPath && (msg.includes("parse error") || msg.includes("Invalid"))) {
+          const ext = extname(resolvedPath).toLowerCase();
+          const hint =
+            ext === ".json"
+              ? "File may contain invalid JSON."
+              : `File extension is '${ext}' — ensure it contains valid JSON.`;
+          return result(err(TOOL_JQ, `${msg} ${hint}`, { meta: { exitCode: exitCode ?? -1 } }));
+        }
+        return result(err(TOOL_JQ, msg, { meta: { exitCode: exitCode ?? -1 } }));
+      }
+
+      const trimmed = stripTrailing(stdout);
+      if (!trimmed) {
+        return result(
+          ok(TOOL_JQ, "Empty result", {
+            warnings,
+            meta: { expressionOverridden: Boolean(expressionOverridden), truncated: false },
+          }),
+        );
+      }
+
+      const { output, totalLines, totalBytes, truncated } = collectOutput(trimmed);
+      return result(
+        ok(TOOL_JQ, truncated ? "Query completed; truncated" : `Query completed (${totalLines} lines)`, {
+          content: output,
+          warnings,
+          meta: { totalLines, totalBytes, truncated, expressionOverridden: Boolean(expressionOverridden) },
+        }),
+      );
+    },
+  });
+}

--- a/addons/git-query-tools/types.ts
+++ b/addons/git-query-tools/types.ts
@@ -1,0 +1,28 @@
+/**
+ * types.ts — Shared interfaces for git-query-tools extension.
+ */
+
+export interface CollectResult {
+  output: string;
+  totalLines: number;
+  totalBytes: number;
+  truncated: boolean;
+}
+
+export type ToolMeta = Record<string, string | number | boolean | null>;
+
+export interface ToolEnvelope {
+  tool: string;
+  status: "ok" | "error";
+  summary: string;
+  content?: string;
+  warnings?: string[];
+  meta?: ToolMeta;
+}
+
+export interface SpawnResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signalCode: string | null;
+}

--- a/addons/git-query-tools/validation.ts
+++ b/addons/git-query-tools/validation.ts
@@ -1,0 +1,66 @@
+/**
+ * validation.ts — Path security and input validation helpers for git-query-tools.
+ */
+
+import { resolve, relative } from "node:path";
+import { BASE_DIR } from "./constants.js";
+
+export function safePath(file: string | undefined): { resolved: string; error?: string } {
+  if (!file) return { resolved: BASE_DIR };
+  const resolved = resolve(BASE_DIR, file);
+  if (!resolved.startsWith(BASE_DIR + "/") && resolved !== BASE_DIR) {
+    return { resolved: "", error: "path outside workspace" };
+  }
+  return { resolved };
+}
+
+export function relPath(file: string): string {
+  const r = resolve(BASE_DIR, file);
+  return relative(BASE_DIR, r);
+}
+
+const JQ_DENYLIST =
+  /(?:^|\b)(env|debug|input|inputs|halt|stderr|builtins)(?:\b|$)|\$ENV|\$__loc__|\bpath\s*\(|\bgetpath\b/;
+
+/**
+ * Returns an error string if the jq expression uses blocked builtins, or null if safe.
+ * Allows .env (key access) but blocks bare `env`, `$ENV`, etc.
+ */
+export function checkJqExpression(expr: string): string | null {
+  const stripped = expr.replace(/\.\w+/g, "");
+  if (JQ_DENYLIST.test(stripped)) return "blocked jq builtin";
+  return null;
+}
+
+export function validateText(value: string | undefined, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  const t = value.trim();
+  if (!t) return `'${field}' cannot be empty`;
+  if (/\r|\n/.test(t)) return `'${field}' must be a single-line value`;
+  if (!/[A-Za-z0-9]/.test(t)) return `'${field}' must contain at least one letter or number`;
+  return undefined;
+}
+
+export function parseBlameLines(lines?: string): { normalized?: string; error?: string } {
+  if (!lines) return {};
+  const t = lines.trim();
+  if (!t) return { error: "'lines' cannot be empty for blame mode" };
+  const single = t.match(/^(\d+)$/);
+  if (single) {
+    const n = Number(single[1]);
+    if (n < 1) return { error: "'lines' must be positive integers" };
+    return { normalized: `${n},${n}` };
+  }
+  const range = t.match(/^(\d+)(,|:|\.\.|-)(\d+)$/);
+  if (!range) {
+    return {
+      error:
+        "'lines' must be a single line like '10' or a range like '10,20', '10:20', '10..20', or '10-20'",
+    };
+  }
+  const start = Number(range[1]);
+  const end = Number(range[3]);
+  if (start < 1 || end < 1) return { error: "'lines' must use positive integers" };
+  if (start > end) return { error: "'lines' start must be <= end" };
+  return { normalized: `${start},${end}` };
+}

--- a/catalog.json
+++ b/catalog.json
@@ -212,7 +212,9 @@
         "json",
         "query"
       ],
-      "skills": [],
+      "skills": [
+        "git-query-tools"
+      ],
       "install": {
         "kind": "tarball",
         "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-git-query-tools-0.1.0.tgz"

--- a/catalog.json
+++ b/catalog.json
@@ -201,6 +201,29 @@
       "contributors": []
     },
     {
+      "slug": "git-query-tools",
+      "name": "@rcarmo/piclaw-addon-git-query-tools",
+      "version": "0.1.0",
+      "type": "extension",
+      "description": "Git history and JSON query tools for piclaw agents",
+      "path": "addons/git-query-tools",
+      "tags": [
+        "git",
+        "json",
+        "query"
+      ],
+      "skills": [],
+      "install": {
+        "kind": "tarball",
+        "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-git-query-tools-0.1.0.tgz"
+      },
+      "owner": {
+        "login": "cjnova",
+        "url": "https://github.com/cjnova"
+      },
+      "contributors": []
+    },
+    {
       "slug": "imap",
       "name": "@rcarmo/piclaw-addon-imap",
       "version": "0.1.0",

--- a/catalog.json
+++ b/catalog.json
@@ -217,6 +217,7 @@
         "kind": "tarball",
         "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-git-query-tools-0.1.0.tgz"
       },
+      "updatedAt": "2026-04-28",
       "owner": {
         "login": "cjnova",
         "url": "https://github.com/cjnova"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
       "addons/dev-tools/index.ts",
       "addons/drawio-editor/index.ts",
       "addons/eml-viewer/index.ts",
+      "addons/git-query-tools/index.ts",
       "addons/imap/index.ts",
       "addons/kanban-board-widget/index.ts",
       "addons/observability/index.ts",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "skills": [
       "addons/autoresearch/skills",
       "addons/delegate/skills",
+      "addons/git-query-tools/skills",
       "addons/settings-dialog-screenshot/skills"
     ]
   },
@@ -56,6 +57,10 @@
       {
         "name": "delegate",
         "path": "./addons/delegate/skills/delegate"
+      },
+      {
+        "name": "git-query-tools",
+        "path": "./addons/git-query-tools/skills/git-query-tools/SKILL.md"
       },
       {
         "name": "settings-dialog-screenshot",


### PR DESCRIPTION
Adds the git-query-tools extension (`@rcarmo/piclaw-addon-git-query-tools` v0.1.0).

## Tools provided

- `git_history`: Query git log with modes: `log`, `content_search`, `message_search`, `blame`. Supports filtering by file, author, date, diff output, and line ranges.
- `json_query`: Transform and filter JSON data using jq expressions. Supports compact output, raw strings, slurp mode, and key listing.

## Changes

- `addons/git-query-tools/` — extension entry point, tool implementation, and skill
- `catalog.json` — regenerated with new addon entry (owner: cjnova)
- `package.json` — updated by sync-catalog

## Verification

- `bun scripts/sync-catalog.ts --check` → metadata already in sync
- `bunx tsc --noEmit` — pre-existing type errors across repo (same pattern as other addons); no new errors introduced by this addon beyond the TS2339/TS7006 pattern already present in delegate, portainer, dev-tools, etc.