### PR TITLE
fix(late-night-regrets): use working message API

### DIFF
--- a/addons/late-night-regrets/index.test.ts
+++ b/addons/late-night-regrets/index.test.ts
@@ -45,4 +45,28 @@ describe("late-night-regrets", () => {
     expect(typeof mod.getTrainScriptPath).toBe("function");
     expect(typeof mod.getAttentionFilePath).toBe("function");
   });
+
+  test("/regrets uses the supported working-message UI API", async () => {
+    const mod = await import("./index.ts");
+    let handler: ((args: string, ctx: unknown) => Promise<void>) | undefined;
+    mod.default({
+      on: () => {},
+      registerCommand: (name: string, definition: { handler: typeof handler }) => {
+        if (name === "regrets") handler = definition.handler;
+      },
+    } as any);
+
+    const workingMessages: Array<string | undefined> = [];
+    const notifications: string[] = [];
+    expect(handler).toBeDefined();
+    await handler!("", {
+      ui: {
+        setWorkingMessage: (message?: string) => workingMessages.push(message),
+        notify: (message: string) => notifications.push(message),
+      },
+    });
+
+    expect(workingMessages).toEqual(["Running interaction quality classifier…"]);
+    expect(notifications).toEqual(["Running Late Night Regrets classifier and reflection…"]);
+  });
 });

--- a/addons/late-night-regrets/index.ts
+++ b/addons/late-night-regrets/index.ts
@@ -142,7 +142,7 @@ export default function lateNightRegretsExtension(pi: ExtensionAPI): void {
         ctx.ui.notify("Late Night Regrets is disabled in settings.", "warning");
         return;
       }
-      ctx.ui.setWorking("Running interaction quality classifier…");
+      ctx.ui.setWorkingMessage("Running interaction quality classifier…");
       ctx.ui.notify("Running Late Night Regrets classifier and reflection…", "info");
     },
   });

--- a/addons/late-night-regrets/package.json
+++ b/addons/late-night-regrets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcarmo/piclaw-addon-late-night-regrets",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Nightly Bayesian interaction-quality classifier — trains on chat history, flags behavioral patterns, and writes self-improvement reflections",
   "type": "module",
   "main": "index.ts",

--- a/catalog.json
+++ b/catalog.json
@@ -427,7 +427,7 @@
         "kind": "tarball",
         "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-late-night-regrets-0.1.3.tgz"
       },
-      "updatedAt": "2026-07-26"
+      "updatedAt": "2026-08-30"
     },
     {
       "slug": "lite-term",

--- a/catalog.json
+++ b/catalog.json
@@ -409,7 +409,7 @@
     {
       "slug": "late-night-regrets",
       "name": "@rcarmo/piclaw-addon-late-night-regrets",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "type": "extension",
       "description": "Nightly Bayesian interaction-quality classifier — trains on chat history, flags behavioral patterns, and writes self-improvement reflections",
       "path": "addons/late-night-regrets",
@@ -425,7 +425,7 @@
       "skills": [],
       "install": {
         "kind": "tarball",
-        "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-late-night-regrets-0.1.2.tgz"
+        "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-late-night-regrets-0.1.3.tgz"
       },
       "updatedAt": "2026-07-26"
     },


### PR DESCRIPTION
## Summary

Fix `/regrets` to use the supported working-message UI API.

Fixes #93.

## Changes

- replace `ctx.ui.setWorking(...)` with `ctx.ui.setWorkingMessage(...)`
- add a regression test that invokes the registered `/regrets` handler
- bump `@rcarmo/piclaw-addon-late-night-regrets` to `0.1.3`
- update the generated catalog metadata

## Tests

- `bun test addons/late-night-regrets/index.test.ts`
- `bun run check:catalog`
- `bun run typecheck:earendil-compat`
- `bun run test:earendil-compat`
- `bun test standalone-import.test.ts`
- `bun pm pack --dry-run`
