### PR TITLE
fix(office-tools): make PDF rendering standalone

### DIFF
--- a/addons/office-tools/README.md
+++ b/addons/office-tools/README.md
@@ -19,7 +19,7 @@ Creates `.docx`, `.xlsx`, `.pptx`, or `.pdf` from Markdown. Output paths must re
 - DOCX uses the bundled `assets/docx-template.zip`.
 - XLSX is generated with the packaged spreadsheet implementation.
 - PPTX uses the vendored PptxGenJS build.
-- PDF uses the bundled `assets/md2pdf.css` and the host PDF renderer.
+- PDF uses the bundled `assets/md2pdf.css` and a package-local CDP renderer. It launches an isolated headless Edge/Chrome/Chromium profile on a free debugging port rather than attaching to unrelated browser automation sessions.
 
 ## Assets
 
@@ -27,4 +27,4 @@ Creates `.docx`, `.xlsx`, `.pptx`, or `.pdf` from Markdown. Output paths must re
 - `assets/md2pdf.css` — Markdown-to-PDF stylesheet
 - `vendor/pptxgenjs/pptxgen.cjs.js` — PPTX generator
 
-The package uses the shared `@sinclair/typebox` peer. PDF generation imports Piclaw's `../../browser/cdp-browser/cdp.ts` helper, so this package is not self-contained for that operation.
+The package uses the shared `@sinclair/typebox` peer. PDF generation is self-contained and does not import Piclaw runtime internals.

--- a/addons/office-tools/cdp-print.test.ts
+++ b/addons/office-tools/cdp-print.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, expect, test } from "bun:test";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ensureBrowser, findBrowser } from "./cdp-print.ts";
+
+const servers: Server[] = [];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+  for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+test("findBrowser discovers an installed Chromium-family browser", () => {
+  const browser = findBrowser();
+  expect(browser === null || ["Edge", "Chrome", "Chromium"].includes(browser.name)).toBe(true);
+});
+
+test("ensureBrowser skips a CDP port owned by another workflow", async () => {
+  const occupied = await new Promise<number>((resolve, reject) => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ Browser: "unrelated-session", webSocketDebuggerUrl: "ws://127.0.0.1/ignored" }));
+    });
+    servers.push(server);
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as { port: number }).port));
+  });
+  const profileRoot = mkdtempSync(join(tmpdir(), "office-tools-cdp-test-"));
+  tempDirs.push(profileRoot);
+  const result = await ensureBrowser(undefined, {
+    ports: [occupied],
+    browser: { command: "this-browser-must-not-launch", name: "Fake" },
+    profileRoot,
+  });
+  expect(result).toBeNull();
+});

--- a/addons/office-tools/cdp-print.ts
+++ b/addons/office-tools/cdp-print.ts
@@ -1,0 +1,281 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, sep } from "node:path";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+
+export type MaybeAbortSignal = AbortSignal | null | undefined;
+export type BrowserLaunch = { command: string; name: string };
+export const CDP_PORTS = [9224, 9225, 9226, 9227, 9228, 9229, 9230, 9231, 9232, 9233] as const;
+const launchedBrowsers = new Map<number, ChildProcess>();
+
+function abortError(message = "Operation cancelled"): Error {
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal?: MaybeAbortSignal): void {
+  if (signal?.aborted) throw abortError();
+}
+
+function bindAbort(signal: MaybeAbortSignal, onAbort: () => void): () => void {
+  if (!signal) return () => {};
+  if (signal.aborted) {
+    onAbort();
+    return () => {};
+  }
+  signal.addEventListener("abort", onAbort, { once: true });
+  return () => signal.removeEventListener("abort", onAbort);
+}
+
+async function fetchJson(url: string, init: RequestInit = {}, timeoutMs = 3000, signal?: MaybeAbortSignal): Promise<any> {
+  throwIfAborted(signal);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const unbind = bindAbort(signal, () => controller.abort());
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    if (!response.ok) throw new Error(`CDP HTTP ${response.status} for ${url}`);
+    const text = await response.text();
+    return text ? JSON.parse(text) : null;
+  } finally {
+    clearTimeout(timer);
+    unbind();
+  }
+}
+
+async function sleep(ms: number, signal?: MaybeAbortSignal): Promise<void> {
+  throwIfAborted(signal);
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      unbind();
+      resolve();
+    }, ms);
+    const unbind = bindAbort(signal, () => {
+      clearTimeout(timer);
+      reject(abortError());
+    });
+  });
+}
+
+function commandExists(command: string): boolean {
+  try {
+    return (spawnSync(command, ["--version"], { stdio: "ignore", windowsHide: true }).status ?? 1) === 0;
+  } catch {
+    return false;
+  }
+}
+
+function browserExists(candidate: BrowserLaunch): boolean {
+  const pathLike = candidate.command.includes(sep) || candidate.command.includes("/") || candidate.command.includes("\\");
+  return pathLike ? existsSync(candidate.command) : commandExists(candidate.command);
+}
+
+export function findBrowser(): BrowserLaunch | null {
+  const candidates: BrowserLaunch[] = [];
+  if (process.platform === "win32") {
+    const pf86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+    const pf = process.env.ProgramFiles ?? "C:\\Program Files";
+    const local = process.env.LOCALAPPDATA ?? "";
+    candidates.push(
+      { command: join(pf86, "Microsoft/Edge/Application/msedge.exe"), name: "Edge" },
+      { command: join(pf, "Microsoft/Edge/Application/msedge.exe"), name: "Edge" },
+      { command: join(local, "Microsoft/Edge/Application/msedge.exe"), name: "Edge" },
+      { command: join(pf, "Google/Chrome/Application/chrome.exe"), name: "Chrome" },
+      { command: join(pf86, "Google/Chrome/Application/chrome.exe"), name: "Chrome" },
+      { command: join(local, "Google/Chrome/Application/chrome.exe"), name: "Chrome" },
+      { command: "msedge.exe", name: "Edge" },
+      { command: "chrome.exe", name: "Chrome" },
+    );
+  } else if (process.platform === "darwin") {
+    candidates.push(
+      { command: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge", name: "Edge" },
+      { command: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome", name: "Chrome" },
+      { command: "/Applications/Chromium.app/Contents/MacOS/Chromium", name: "Chromium" },
+    );
+  } else {
+    candidates.push(
+      { command: "/usr/bin/microsoft-edge", name: "Edge" },
+      { command: "/usr/bin/google-chrome", name: "Chrome" },
+      { command: "/usr/bin/chromium", name: "Chromium" },
+      { command: "/snap/bin/chromium", name: "Chromium" },
+      { command: "microsoft-edge", name: "Edge" },
+      { command: "google-chrome", name: "Chrome" },
+      { command: "chromium", name: "Chromium" },
+    );
+  }
+  return candidates.find(browserExists) ?? null;
+}
+
+export async function findCdpPort(signal?: MaybeAbortSignal): Promise<number | null> {
+  // Reuse only a browser launched by this helper. Never attach Office export to
+  // an unrelated interactive/automation CDP profile owned by another workflow.
+  for (const [port, child] of launchedBrowsers) {
+    if (child.exitCode !== null) {
+      launchedBrowsers.delete(port);
+      continue;
+    }
+    try {
+      const version = await fetchJson(`http://127.0.0.1:${port}/json/version`, {}, 800, signal);
+      if (version && typeof version === "object") return port;
+    } catch (error) {
+      if ((error as Error).name === "AbortError" && signal?.aborted) throw error;
+    }
+  }
+  return null;
+}
+
+export async function ensureBrowser(
+  signal?: MaybeAbortSignal,
+  options: { ports?: readonly number[]; browser?: BrowserLaunch | null; profileRoot?: string } = {},
+): Promise<number | null> {
+  const existing = await findCdpPort(signal);
+  if (existing) return existing;
+  const browser = options.browser === undefined ? findBrowser() : options.browser;
+  if (!browser) return null;
+
+  for (const port of options.ports ?? CDP_PORTS) {
+    throwIfAborted(signal);
+    // Skip ports owned by other browser automation sessions.
+    try {
+      await fetchJson(`http://127.0.0.1:${port}/json/version`, {}, 400, signal);
+      continue;
+    } catch (error) {
+      if ((error as Error).name === "AbortError" && signal?.aborted) throw error;
+    }
+    const profile = join(options.profileRoot ?? tmpdir(), `piclaw-office-tools-cdp-${process.pid}-${port}`);
+    mkdirSync(profile, { recursive: true });
+    const child = spawn(browser.command, [
+      `--remote-debugging-port=${port}`,
+      `--user-data-dir=${profile}`,
+      "--headless=new",
+      "--no-first-run",
+      "--disable-default-apps",
+      "--disable-features=AutomationControlled",
+      "about:blank",
+    ], { stdio: "ignore", windowsHide: true });
+    launchedBrowsers.set(port, child);
+    for (let attempt = 0; attempt < 20; attempt++) {
+      try {
+        await fetchJson(`http://127.0.0.1:${port}/json/version`, {}, 800, signal);
+        return port;
+      } catch (error) {
+        if ((error as Error).name === "AbortError" && signal?.aborted) throw error;
+        if (child.exitCode !== null) break;
+        await sleep(250, signal);
+      }
+    }
+    launchedBrowsers.delete(port);
+    try { child.kill(); } catch {}
+  }
+  return null;
+}
+
+async function openTab(port: number, url: string, signal?: MaybeAbortSignal): Promise<any> {
+  return fetchJson(`http://127.0.0.1:${port}/json/new?${encodeURIComponent(url)}`, { method: "PUT" }, 5000, signal);
+}
+
+async function closeTab(port: number, targetId: string): Promise<void> {
+  try {
+    await fetchJson(`http://127.0.0.1:${port}/json/close/${targetId}`, { method: "PUT" }, 3000);
+  } catch {}
+}
+
+async function connect(webSocketDebuggerUrl: string, signal?: MaybeAbortSignal): Promise<WebSocket> {
+  throwIfAborted(signal);
+  return await new Promise<WebSocket>((resolve, reject) => {
+    const ws = new WebSocket(webSocketDebuggerUrl);
+    let settled = false;
+    const cleanup = () => {
+      clearTimeout(timer);
+      unbind();
+    };
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      try { ws.close(); } catch {}
+      reject(error);
+    };
+    const timer = setTimeout(() => fail(new Error("CDP websocket timeout")), 5000);
+    const unbind = bindAbort(signal, () => fail(abortError()));
+    ws.addEventListener("open", () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(ws);
+    }, { once: true });
+    ws.addEventListener("error", () => fail(new Error("CDP websocket connection failed")), { once: true });
+  });
+}
+
+let nextCommandId = 1;
+async function send(ws: WebSocket, method: string, params: any, signal?: MaybeAbortSignal): Promise<any> {
+  throwIfAborted(signal);
+  const id = nextCommandId++;
+  return await new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      unbind();
+      ws.removeEventListener("message", onMessage);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`CDP command timed out: ${method}`));
+    }, 15000);
+    const unbind = bindAbort(signal, () => {
+      cleanup();
+      reject(abortError());
+    });
+    const onMessage = (event: MessageEvent) => {
+      try {
+        const message = JSON.parse(String(event.data));
+        if (message.id !== id) return;
+        cleanup();
+        if (message.error) reject(new Error(`CDP ${method}: ${message.error.message ?? message.error.code}`));
+        else resolve(message.result ?? null);
+      } catch {}
+    };
+    ws.addEventListener("message", onMessage);
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+}
+
+export interface PrintToPdfOptions {
+  port: number;
+  outPath: string;
+  url: string;
+  waitMs?: number;
+  printBackground?: boolean;
+  preferCSSPageSize?: boolean;
+  signal?: MaybeAbortSignal;
+}
+
+export async function printToPdf(options: PrintToPdfOptions): Promise<{ file: string; title?: string; url?: string }> {
+  const target = await openTab(options.port, options.url, options.signal);
+  if (!target?.id || !target?.webSocketDebuggerUrl) throw new Error("CDP did not create a printable page target");
+  try {
+    await sleep(options.waitMs ?? 1000, options.signal);
+    const ws = await connect(target.webSocketDebuggerUrl, options.signal);
+    try {
+      await send(ws, "Page.enable", {}, options.signal);
+      const printed = await send(ws, "Page.printToPDF", {
+        printBackground: options.printBackground ?? true,
+        preferCSSPageSize: options.preferCSSPageSize ?? true,
+      }, options.signal);
+      if (!printed?.data) throw new Error("CDP returned no PDF data");
+      mkdirSync(dirname(options.outPath), { recursive: true });
+      writeFileSync(options.outPath, Buffer.from(printed.data, "base64"));
+      return { file: options.outPath, title: target.title, url: target.url };
+    } finally {
+      try { ws.close(); } catch {}
+    }
+  } finally {
+    await closeTab(options.port, target.id);
+    const launched = launchedBrowsers.get(options.port);
+    if (launched) {
+      launchedBrowsers.delete(options.port);
+      try { launched.kill(); } catch {}
+    }
+  }
+}

--- a/addons/office-tools/index.test.ts
+++ b/addons/office-tools/index.test.ts
@@ -19,3 +19,10 @@ test("office schemas and extension entrypoint import standalone", () => {
   expect(officeWriteParameters.properties.path).toMatchObject({ type: "string" });
   expect(officeWriteParameters.properties.markdown).toMatchObject({ type: "string" });
 });
+
+test("PDF renderer stays inside the standalone package", () => {
+  const source = readFileSync(join(import.meta.dir, "index.ts"), "utf8");
+  expect(source).toContain('import("./cdp-print.ts")');
+  expect(source).not.toContain("../../browser/cdp-browser/cdp.ts");
+  expect(readFileSync(join(import.meta.dir, "cdp-print.ts"), "utf8")).toContain("export async function printToPdf");
+});

--- a/addons/office-tools/index.ts
+++ b/addons/office-tools/index.ts
@@ -22,7 +22,7 @@ const XLSX_PACKAGE = "xlsx";
 let cachedXlsx: any | null = null;
 let cachedPptxGenJs: any | null = null;
 let cachedFflate: any | null = null;
-let cachedCdpModule: Promise<typeof import("../../browser/cdp-browser/cdp.ts")> | null = null;
+let cachedCdpModule: Promise<typeof import("./cdp-print.ts")> | null = null;
 const DOCX_TEMPLATE_PATH = resolve(ASSETS_DIR, "docx-template.zip");
 const PDF_CSS_PATH = resolve(ASSETS_DIR, "md2pdf.css");
 
@@ -44,8 +44,8 @@ function getFflate(): any {
   return cachedFflate;
 }
 
-async function getCdpModule(): Promise<typeof import("../../browser/cdp-browser/cdp.ts")> {
-  if (!cachedCdpModule) cachedCdpModule = import("../../browser/cdp-browser/cdp.ts");
+async function getCdpModule(): Promise<typeof import("./cdp-print.ts")> {
+  if (!cachedCdpModule) cachedCdpModule = import("./cdp-print.ts");
   return await cachedCdpModule;
 }
 

--- a/addons/office-tools/package.json
+++ b/addons/office-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcarmo/piclaw-addon-office-tools",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Office document read/write tools for Piclaw (docx, xlsx, pptx, odt, md→pdf)",
   "type": "module",
   "main": "index.ts",

--- a/catalog.json
+++ b/catalog.json
@@ -540,7 +540,7 @@
     {
       "slug": "office-tools",
       "name": "@rcarmo/piclaw-addon-office-tools",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "type": "extension",
       "description": "Office document read/write tools for Piclaw (docx, xlsx, pptx, odt, md→pdf)",
       "path": "addons/office-tools",
@@ -556,7 +556,7 @@
       "skills": [],
       "install": {
         "kind": "tarball",
-        "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-office-tools-0.1.3.tgz"
+        "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-office-tools-0.1.4.tgz"
       },
       "updatedAt": "2026-09-08"
     },

--- a/catalog.json
+++ b/catalog.json
@@ -558,7 +558,7 @@
         "kind": "tarball",
         "spec": "https://rcarmo.github.io/piclaw-addons/packages/piclaw-addon-office-tools-0.1.4.tgz"
       },
-      "updatedAt": "2026-09-08"
+      "updatedAt": "2026-09-10"
     },
     {
       "slug": "office-viewer",


### PR DESCRIPTION
## Summary

- make `office-tools` PDF generation self-contained instead of importing `../../browser/cdp-browser/cdp.ts` outside the package
- add a package-local CDP renderer that launches an isolated headless Chromium profile and skips debugging ports owned by other workflows
- add focused package-boundary and occupied-port regression tests
- bump `@rcarmo/piclaw-addon-office-tools` to `0.1.4` and refresh generated catalog metadata

## Why

The published `0.1.3` tarball loads, but its deferred Markdown-to-PDF path resolves a file outside the package. That path is absent after standalone installation. Reusing any listening CDP port also risks attaching document export to an unrelated interactive automation session.

## Validation

- `bun test addons/office-tools/index.test.ts addons/office-tools/cdp-print.test.ts` — 5 passed
- `bun run check:catalog` — passed
- bundled the source entrypoint with Bun 1.4.1 — passed
- packed `0.1.4` and bundled the extracted package entrypoint — passed
- local Windows runtime: three consecutive PDF exports plus a post-restart export produced valid `%PDF-` files and cleaned temporary HTML

## Known Windows test-harness limitation

`bun test standalone-import.test.ts --test-name-pattern office-tools` could not run on this managed Windows host because the existing test uses `symlinkSync(..., "dir")` and the process lacks symlink privilege (`EPERM`). The packed-artifact bundle test exercises the same standalone package boundary without that host-specific symlink requirement.
